### PR TITLE
[FIX] deprecated name on yarn link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 1. You need to symlink your local morpher to your Views project.
 
     * In your local instance of the morpher run `yarn link` in the root directory.
-    * In your project where you are using Views run `yarn link views-morph` in the root directory.
+    * In your project where you are using Views run `yarn link @viewstools/morph` in the root directory.
 
 2. Put in your `debugger` statements where necessary.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@
 
 3. Run `yarn prepare` in the morpher directory to bundle your code.
 
-4. In your views project run `node --inspect ./node_modules/views-morph/cli.js . --watch`. This will watch your current directory. If you just want to watch a subdirectory within that you can replace the `.` in that command with the path to the subdirectory.
+4. In your views project run `node --inspect ./node_modules/@viewstools/morph/cli.js . --watch`. This will watch your current directory. If you just want to watch a subdirectory within that you can replace the `.` in that command with the path to the subdirectory.
 
 5. In chrome open your dev tools on any tab. Click on the green icon at the top to open the node dev tools. Bingo! :tada:
 


### PR DESCRIPTION
the Contribute guide tells us to do `yarn link views-morph` which gives the following error:
`error No registered module found called "views-morph".`
Apparently the module changed name at some point so now the following command is the one that works for me @dariocravero 
`yarn link @viewstools/morph`