### PR TITLE
[ENHANCEMENT] Certain properties should only be applicable to specific blocks 

### DIFF
--- a/parse/index.js
+++ b/parse/index.js
@@ -289,6 +289,14 @@ export default ({
           block,
         })
 
+        if (!isFontable(block.name) && name.indexOf('font') >= 0) {
+          warnings.push({
+            loc,
+            type: `The prop ${name} isn't supported on block ${block.name}`,
+            line,
+          })
+        }
+
         if (block.isBasic) {
           if (tags.unsupportedShorthand) {
             warnings.push({


### PR DESCRIPTION
Telling user that font related prop is not valid for non fontable blocks
Relates to #30 