### PR TITLE
Animations 2

### DIFF
--- a/__tests__/__snapshots__/react.js.snap
+++ b/__tests__/__snapshots__/react.js.snap
@@ -654,11 +654,11 @@ module.exports = {
 exports[`react-dom parses react-dom Action 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import SubButton from './SubButton.view.js';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const Vertical = css({
   label: 'Vertical',
@@ -792,25 +792,20 @@ export default Action;
 exports[`react-dom parses react-dom AnimatedButton 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
+import { animated, Spring } from '@viewstools/animations/dom';
 import { css } from 'emotion';
-import Animated from 'animated/lib/targets/react-dom';
-import PropTypes from 'prop-types';
-const getAnimatedValue = (animatedValue, from, to) =>
-  animatedValue.interpolate({
-    inputRange: [0, 1],
-    outputRange: [from, to],
-  });
 
 const AnimatedButton1 = css({
   label: 'AnimatedButton1',
   backgroundColor: 'red',
-  transition: 'transform 150ms ease-in 0ms',
+  transition: 'transform 150ms ease-in 0ms, transform 150ms ease-in-out 0ms',
   willChange: 'opacity, transform',
   opacity: 'var(--opacity)',
   transform:
-    'rotateX(var(--rotateX)) translateX(var(--translateX)) translateY(var(--translateY))',
+    'rotateX(var(--rotateX)) rotateY(var(--rotateY)) translateX(var(--translateX)) translateY(var(--translateY))',
 });
 const Text = css({
   label: 'Text',
@@ -824,56 +819,68 @@ class AnimatedButton extends React.Component {
     const { context, props } = this;
 
     return (
-      <AnimatedSpringComponent
-        config={{ bounciness: 10, speed: 1 }}
+      <Spring
+        native
+        bounciness={10}
+        speed={1}
         delay={0}
         to={{ opacity: props.isOn ? 1 : 0.75 }}
       >
-        animatedAnimatedButton => (<AnimatedSpringComponent
-          config={{ bounciness: 15, speed: 2 }}
-          delay={0}
-          to={{ translateX: props.isOn ? 20 : 10 }}
-        >
-          animatedAnimatedButton => (<AnimatedSpringComponent
-            config={{ bounciness: 8, speed: 12 }}
+        {animatedAnimatedButton => (
+          <Spring
+            native
+            bounciness={15}
+            speed={2}
             delay={0}
-            to={{ color: props.isOn ? 'blue' : 'red' }}
+            to={{ translateX: \`\${props.isOn ? 20 : 10}px\` }}
           >
-            animatedText => (<Animated.button
-              data-test-id={\`\${props['data-test-id'] || 'AnimatedButton'}|\${
-                props.isOn ? 'isOn|' : ''
-              }\`}
-              onClick={event =>
-                context.track({
-                  block: props['data-test-id'] || 'AnimatedButton',
-                  action: 'click',
-                  callback: props.onClick,
-                  event,
-                  props,
-                })
-              }
-              style={{
-                '--opacity': animatedAnimatedButton.opacity,
-                '--translateX': animatedAnimatedButton.translateX,
-                '--translateY': \`\${props.isOn ? 30 : 0}px\`,
-                '--rotateX': \`\${props.isOn ? 20 : 10}deg\`,
-              }}
-              className={\`views-block \${AnimatedButton1}\`}
-            >
-              <span
-                data-test-id={\`AnimatedButton.Text|\${
-                  props.isOn ? 'isOn|' : ''
-                }\`}
-                style={{ '--color': animatedText.color }}
-                className={\`views-block \${Text}\`}
+            {animatedAnimatedButton1 => (
+              <Spring
+                native
+                delay={0}
+                speed={12}
+                bounciness={8}
+                to={{ color: props.isOn ? 'blue' : 'red' }}
               >
-                hey
-              </span>
-              {props.children}
-            </Animated.button>)}
-          </AnimatedSpringComponent>)}
-        </AnimatedSpringComponent>)}
-      </AnimatedSpringComponent>
+                {animatedText => (
+                  <animated.button
+                    data-test-id={\`\${props['data-test-id'] ||
+                      'AnimatedButton'}|\${props.isOn ? 'isOn|' : ''}\`}
+                    onClick={event =>
+                      context.track({
+                        block: props['data-test-id'] || 'AnimatedButton',
+                        action: 'click',
+                        callback: props.onClick,
+                        event,
+                        props,
+                      })
+                    }
+                    style={{
+                      '--opacity': animatedAnimatedButton.opacity,
+                      '--translateX': animatedAnimatedButton1.translateX,
+                      '--translateY': \`\${props.isOn ? 30 : 0}px\`,
+                      '--rotateX': \`\${props.isOn ? 20 : 10}deg\`,
+                      '--rotateY': \`\${props.isOn ? 20 : 10}deg\`,
+                    }}
+                    className={\`views-block \${AnimatedButton1}\`}
+                  >
+                    <span
+                      data-test-id={\`AnimatedButton.Text|\${
+                        props.isOn ? 'isOn|' : ''
+                      }\`}
+                      style={{ '--color': animatedText.color }}
+                      className={\`views-block \${Text}\`}
+                    >
+                      hey
+                    </span>
+                    {props.children}
+                  </animated.button>
+                )}
+              </Spring>
+            )}
+          </Spring>
+        )}
+      </Spring>
     );
   }
 }
@@ -900,22 +907,17 @@ Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
+import { animated, Spring } from '@viewstools/animations/dom';
 import { css } from 'emotion';
-import Animated from 'animated/lib/targets/react-dom';
-const getAnimatedValue = (animatedValue, from, to) =>
-  animatedValue.interpolate({
-    inputRange: [0, 1],
-    outputRange: [from, to],
-  });
 
 const AnimatedButton1 = css({
   label: 'AnimatedButton1',
   backgroundColor: 'red',
-  transition: 'transform 150ms ease-in 0ms',
+  transition: 'transform 150ms ease-in 0ms, transform 150ms ease-in-out 0ms',
   willChange: 'opacity, transform',
   opacity: 'var(--opacity)',
   transform:
-    'rotateX(var(--rotateX)) translateX(var(--translateX)) translateY(var(--translateY))',
+    'rotateX(var(--rotateX)) rotateY(var(--rotateY)) translateX(var(--translateX)) translateY(var(--translateY))',
 });
 const Text = css({
   label: 'Text',
@@ -929,48 +931,60 @@ class AnimatedButton extends React.Component {
     const { props } = this;
 
     return (
-      <AnimatedSpringComponent
-        config={{ bounciness: 10, speed: 1 }}
+      <Spring
+        native
+        bounciness={10}
+        speed={1}
         delay={0}
         to={{ opacity: props.isOn ? 1 : 0.75 }}
       >
-        animatedAnimatedButton => (<AnimatedSpringComponent
-          config={{ bounciness: 15, speed: 2 }}
-          delay={0}
-          to={{ translateX: props.isOn ? 20 : 10 }}
-        >
-          animatedAnimatedButton => (<AnimatedSpringComponent
-            config={{ bounciness: 8, speed: 12 }}
+        {animatedAnimatedButton => (
+          <Spring
+            native
+            bounciness={15}
+            speed={2}
             delay={0}
-            to={{ color: props.isOn ? 'blue' : 'red' }}
+            to={{ translateX: \`\${props.isOn ? 20 : 10}px\` }}
           >
-            animatedText => (<Animated.button
-              data-test-id={\`\${props['data-test-id'] || 'AnimatedButton'}|\${
-                props.isOn ? 'isOn|' : ''
-              }\`}
-              onClick={props.onClick}
-              style={{
-                '--opacity': animatedAnimatedButton.opacity,
-                '--translateX': animatedAnimatedButton.translateX,
-                '--translateY': \`\${props.isOn ? 30 : 0}px\`,
-                '--rotateX': \`\${props.isOn ? 20 : 10}deg\`,
-              }}
-              className={\`views-block \${AnimatedButton1}\`}
-            >
-              <span
-                data-test-id={\`AnimatedButton.Text|\${
-                  props.isOn ? 'isOn|' : ''
-                }\`}
-                style={{ '--color': animatedText.color }}
-                className={\`views-block \${Text}\`}
+            {animatedAnimatedButton1 => (
+              <Spring
+                native
+                delay={0}
+                speed={12}
+                bounciness={8}
+                to={{ color: props.isOn ? 'blue' : 'red' }}
               >
-                hey
-              </span>
-              {props.children}
-            </Animated.button>)}
-          </AnimatedSpringComponent>)}
-        </AnimatedSpringComponent>)}
-      </AnimatedSpringComponent>
+                {animatedText => (
+                  <animated.button
+                    data-test-id={\`\${props['data-test-id'] ||
+                      'AnimatedButton'}|\${props.isOn ? 'isOn|' : ''}\`}
+                    onClick={props.onClick}
+                    style={{
+                      '--opacity': animatedAnimatedButton.opacity,
+                      '--translateX': animatedAnimatedButton1.translateX,
+                      '--translateY': \`\${props.isOn ? 30 : 0}px\`,
+                      '--rotateX': \`\${props.isOn ? 20 : 10}deg\`,
+                      '--rotateY': \`\${props.isOn ? 20 : 10}deg\`,
+                    }}
+                    className={\`views-block \${AnimatedButton1}\`}
+                  >
+                    <span
+                      data-test-id={\`AnimatedButton.Text|\${
+                        props.isOn ? 'isOn|' : ''
+                      }\`}
+                      style={{ '--color': animatedText.color }}
+                      className={\`views-block \${Text}\`}
+                    >
+                      hey
+                    </span>
+                    {props.children}
+                  </animated.button>
+                )}
+              </Spring>
+            )}
+          </Spring>
+        )}
+      </Spring>
     );
   }
 }
@@ -992,10 +1006,10 @@ export default AnimatedButton;
 exports[`react-dom parses react-dom AppRegionDrag 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const Vertical = css({
   label: 'Vertical',
@@ -1066,10 +1080,10 @@ export default AppRegionDrag;
 exports[`react-dom parses react-dom BackgroundImage 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const Vertical = css({
   label: 'Vertical',
@@ -1175,10 +1189,10 @@ export default BackgroundImage;
 exports[`react-dom parses react-dom Border 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const Border1 = css({
   label: 'Border1',
@@ -1412,10 +1426,10 @@ export default Border;
 exports[`react-dom parses react-dom ClassName 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const Vertical = css({ label: 'Vertical', backgroundColor: 'blue' });
 
@@ -1476,10 +1490,10 @@ export default ClassName;
 exports[`react-dom parses react-dom Code 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const Vertical = css({ label: 'Vertical', backgroundColor: 'red' });
 const Text = css({
@@ -1602,9 +1616,9 @@ export default Code;
 exports[`react-dom parses react-dom DefaultProps 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
 
 class DefaultProps extends React.Component {
   render() {
@@ -1701,10 +1715,10 @@ export default DefaultProps;
 exports[`react-dom parses react-dom Display 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const Display1 = css({ label: 'Display1', display: 'block' });
 
@@ -1765,11 +1779,11 @@ export default Display;
 exports[`react-dom parses react-dom DynamicStylesApplyToBasicBlocksOnly 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import SomeThing from './SomeThing.view.js';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const Vertical = css({
   label: 'Vertical',
@@ -1861,9 +1875,9 @@ export default DynamicStylesApplyToBasicBlocksOnly;
 exports[`react-dom parses react-dom EmptyText 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
 
 class EmptyText extends React.Component {
   render() {
@@ -1915,9 +1929,9 @@ export default EmptyText;
 exports[`react-dom parses react-dom GoTo 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
 
 class GoTo extends React.Component {
   render() {
@@ -1985,10 +1999,10 @@ export default GoTo;
 exports[`react-dom parses react-dom Hover 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const Hover1 = css({
   label: 'Hover1',
@@ -2129,9 +2143,9 @@ export default Hover;
 exports[`react-dom parses react-dom JustText 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
 
 class JustText extends React.Component {
   render() {
@@ -2187,10 +2201,10 @@ export default JustText;
 exports[`react-dom parses react-dom ListOfSomething 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import Something from './Something.view.js';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
 
 class ListOfSomething extends React.Component {
   render() {
@@ -2288,10 +2302,10 @@ export default ListOfSomething;
 exports[`react-dom parses react-dom ListWhen 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
 import Card from './Card.view.js';
-import ViewsBaseCss from './ViewsBaseCss.view.js';
 import PropTypes from 'prop-types';
+import React from 'react';
+import ViewsBaseCss from './ViewsBaseCss.view.js';
 
 class ListWhen extends React.Component {
   render() {
@@ -2343,8 +2357,8 @@ export default ListWhen;
 exports[`react-dom parses react-dom ListWhen: react-dom parses react-dom ListWhen debug 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
 import Card from './Card.view.js';
+import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 
 const ListWhen = props => {
@@ -2399,10 +2413,10 @@ export default ListWhen;
 exports[`react-dom parses react-dom ListWithKey 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
 import Card from './Card.view.js';
-import ViewsBaseCss from './ViewsBaseCss.view.js';
 import PropTypes from 'prop-types';
+import React from 'react';
+import ViewsBaseCss from './ViewsBaseCss.view.js';
 
 class ListWithKey extends React.Component {
   render() {
@@ -2449,8 +2463,8 @@ export default ListWithKey;
 exports[`react-dom parses react-dom ListWithKey: react-dom parses react-dom ListWithKey debug 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
 import Card from './Card.view.js';
+import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 
 const ListWithKey = props => {
@@ -2500,11 +2514,11 @@ export default ListWithKey;
 exports[`react-dom parses react-dom LocalImage 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import garfieldPng from './garfield.png';
 import chopperJpg from './chopper.jpg';
-import PropTypes from 'prop-types';
+import garfieldPng from './garfield.png';
 
 class LocalImage extends React.Component {
   render() {
@@ -2539,8 +2553,8 @@ Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import garfieldPng from './garfield.png';
 import chopperJpg from './chopper.jpg';
+import garfieldPng from './garfield.png';
 
 const LocalImage = props => {
   return (
@@ -2566,11 +2580,11 @@ export default LocalImage;
 exports[`react-dom parses react-dom LocalImageSvg 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import chopperSvg from './chopper.svg';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const LocalImageSvg1 = css({
   label: 'LocalImageSvg1',
@@ -2655,9 +2669,9 @@ export default LocalImageSvg;
 exports[`react-dom parses react-dom LocalOrRemoteImageWhenCode 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
 
 class LocalOrRemoteImageWhenCode extends React.Component {
   render() {
@@ -2731,11 +2745,11 @@ export default LocalOrRemoteImageWhenCode;
 exports[`react-dom parses react-dom Locals 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import LocalContainer from './LocalContainer.view.js';
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
 import { Subscribe } from 'unstated';
-import LocalContainer from './LocalContainer.view.js';
 
 const TextLocal = {
   es: 'Hola',
@@ -2791,10 +2805,10 @@ export default Locals;
 exports[`react-dom parses react-dom Locals: react-dom parses react-dom Locals debug 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import LocalContainer from './LocalContainer.view.js';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { Subscribe } from 'unstated';
-import LocalContainer from './LocalContainer.view.js';
 
 const TextLocal = {
   es: 'Hola',
@@ -2843,9 +2857,9 @@ export default Locals;
 exports[`react-dom parses react-dom LocalsFormat 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
 
 const currencyOptions = { style: 'currency', currency: 'USD' };
 const currencyFormatters = {
@@ -3015,9 +3029,9 @@ export default LocalsFormat;
 exports[`react-dom parses react-dom NameIsType 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
 
 class NameIsType extends React.Component {
   render() {
@@ -3073,10 +3087,10 @@ export default NameIsType;
 exports[`react-dom parses react-dom NegativeNumber 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const Text = css({ label: 'Text', marginTop: -10 });
 
@@ -3137,12 +3151,12 @@ export default NegativeNumber;
 exports[`react-dom parses react-dom NestedRoutes 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { Route } from 'react-router-dom';
 import Topic from './Topic.view.js';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { Route } from 'react-router-dom';
 
 class NestedRoutes extends React.Component {
   render() {
@@ -3196,10 +3210,10 @@ exports[`react-dom parses react-dom NestedRoutes: react-dom parses react-dom Nes
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { Route } from 'react-router-dom';
 import Topic from './Topic.view.js';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
+import { Link } from 'react-router-dom';
+import { Route } from 'react-router-dom';
 
 const NestedRoutes = props => {
   return (
@@ -3245,10 +3259,10 @@ export default NestedRoutes;
 exports[`react-dom parses react-dom Scope 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const Scope1 = css({
   label: 'Scope1',
@@ -3353,10 +3367,10 @@ export default Scope;
 exports[`react-dom parses react-dom ScopeOnCustomView 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
 import Button from './Button.view.js';
-import ViewsBaseCss from './ViewsBaseCss.view.js';
 import PropTypes from 'prop-types';
+import React from 'react';
+import ViewsBaseCss from './ViewsBaseCss.view.js';
 
 class ScopeOnCustomView extends React.Component {
   render() {
@@ -3398,8 +3412,8 @@ export default ScopeOnCustomView;
 exports[`react-dom parses react-dom ScopeOnCustomView: react-dom parses react-dom ScopeOnCustomView debug 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
 import Button from './Button.view.js';
+import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 
 const ScopeOnCustomView = props => {
@@ -3435,9 +3449,9 @@ export default ScopeOnCustomView;
 exports[`react-dom parses react-dom ScopePopup 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
 
 class ScopePopup extends React.Component {
   render() {
@@ -3539,10 +3553,10 @@ export default ScopePopup;
 exports[`react-dom parses react-dom ScopePopup2 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const Content = css({
   label: 'Content',
@@ -3681,11 +3695,11 @@ export default ScopePopup2;
 exports[`react-dom parses react-dom ScrollableList 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
 import Card from './Card.view.js';
+import PropTypes from 'prop-types';
+import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const ScrollableList1 = css({
   label: 'ScrollableList1',
@@ -3746,8 +3760,8 @@ export default ScrollableList;
 exports[`react-dom parses react-dom ScrollableList: react-dom parses react-dom ScrollableList debug 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
 import Card from './Card.view.js';
+import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
 
@@ -3812,10 +3826,10 @@ export default ScrollableList;
 exports[`react-dom parses react-dom Shadow 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const BoxShadow = css({
   label: 'BoxShadow',
@@ -3929,10 +3943,10 @@ export default Shadow;
 exports[`react-dom parses react-dom SomeMissingStyle 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const WindowControl = css({
   label: 'WindowControl',
@@ -4048,11 +4062,11 @@ export default SomeMissingStyle;
 exports[`react-dom parses react-dom Teleport 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
-import { Link } from 'react-router-dom';
-import ViewsBaseCss from './ViewsBaseCss.view.js';
-import { css } from 'emotion';
 import PropTypes from 'prop-types';
+import React from 'react';
+import ViewsBaseCss from './ViewsBaseCss.view.js';
+import { Link } from 'react-router-dom';
+import { css } from 'emotion';
 
 const Horizontal = css({ label: 'Horizontal', flexDirection: 'row' });
 
@@ -4090,8 +4104,8 @@ exports[`react-dom parses react-dom Teleport: react-dom parses react-dom Telepor
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
 import React from 'react';
-import { Link } from 'react-router-dom';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
+import { Link } from 'react-router-dom';
 import { css } from 'emotion';
 
 const Horizontal = css({ label: 'Horizontal', flexDirection: 'row' });
@@ -4122,10 +4136,10 @@ export default Teleport;
 exports[`react-dom parses react-dom TestIds 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
 import External from './External.view.js';
-import ViewsBaseCss from './ViewsBaseCss.view.js';
 import PropTypes from 'prop-types';
+import React from 'react';
+import ViewsBaseCss from './ViewsBaseCss.view.js';
 
 class TestIds extends React.Component {
   render() {
@@ -4166,8 +4180,8 @@ export default TestIds;
 exports[`react-dom parses react-dom TestIds: react-dom parses react-dom TestIds debug 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
 import External from './External.view.js';
+import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 
 const TestIds = props => {
@@ -4202,9 +4216,9 @@ export default TestIds;
 exports[`react-dom parses react-dom TextInterpolation 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
 
 class TextInterpolation extends React.Component {
   render() {
@@ -4314,10 +4328,10 @@ export default TextInterpolation;
 exports[`react-dom parses react-dom Transform 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const Transform1 = css({
   label: 'Transform1',
@@ -4438,10 +4452,10 @@ export default Transform;
 exports[`react-dom parses react-dom UseCaptureEmail 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const Email = css({
   label: 'Email',
@@ -4560,9 +4574,9 @@ export default UseCaptureEmail;
 exports[`react-dom parses react-dom UseCaptureFile 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
 
 class UseCaptureFile extends React.Component {
   constructor(props) {
@@ -4633,9 +4647,9 @@ export default UseCaptureFile;
 exports[`react-dom parses react-dom UseCaptureNumber 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
 
 class UseCaptureNumber extends React.Component {
   constructor(props) {
@@ -4712,9 +4726,9 @@ export default UseCaptureNumber;
 exports[`react-dom parses react-dom UseCapturePhone 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
 
 class UseCapturePhone extends React.Component {
   constructor(props) {
@@ -4787,9 +4801,9 @@ export default UseCapturePhone;
 exports[`react-dom parses react-dom UseCaptureSecure 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
 
 class UseCaptureSecure extends React.Component {
   constructor(props) {
@@ -4862,11 +4876,11 @@ export default UseCaptureSecure;
 exports[`react-dom parses react-dom UseCaptureText 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import LocalContainer from './LocalContainer.view.js';
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
 import { Subscribe } from 'unstated';
-import LocalContainer from './LocalContainer.view.js';
 
 const TextLocal = {
   es: 'Escriba sus comentarios aqui...',
@@ -4912,10 +4926,10 @@ export default UseCaptureText;
 exports[`react-dom parses react-dom UseCaptureText: react-dom parses react-dom UseCaptureText debug 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import LocalContainer from './LocalContainer.view.js';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { Subscribe } from 'unstated';
-import LocalContainer from './LocalContainer.view.js';
 
 const TextLocal = {
   es: 'Escriba sus comentarios aqui...',
@@ -4959,9 +4973,9 @@ export default UseCaptureText;
 exports[`react-dom parses react-dom UseCaptureTextArea 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
 
 class UseCaptureTextArea extends React.Component {
   constructor(props) {
@@ -5036,9 +5050,9 @@ export default UseCaptureTextArea;
 exports[`react-dom parses react-dom UseCaptureTextManagedFromOutside 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
 
 class UseCaptureTextManagedFromOutside extends React.Component {
   constructor(props) {
@@ -5120,10 +5134,10 @@ export default UseCaptureTextManagedFromOutside;
 exports[`react-dom parses react-dom UseHorizontal 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const Horizontal = css({
   label: 'Horizontal',
@@ -5196,9 +5210,9 @@ export default UseHorizontal;
 exports[`react-dom parses react-dom UseImage 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
 
 class UseImage extends React.Component {
   render() {
@@ -5266,15 +5280,15 @@ export default UseImage;
 exports[`react-dom parses react-dom UseRouter 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
 import About from './About.view.js';
 import Home from './Home.view.js';
-import { Route } from 'react-router-dom';
-import { BrowserRouter as Router } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import React from 'react';
 import Topics from './Topics.view.js';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { Route } from 'react-router-dom';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const Horizontal = css({ label: 'Horizontal', flexDirection: 'row' });
 
@@ -5348,13 +5362,13 @@ export default UseRouter;
 exports[`react-dom parses react-dom UseRouter: react-dom parses react-dom UseRouter debug 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
 import About from './About.view.js';
 import Home from './Home.view.js';
-import { Route } from 'react-router-dom';
-import { BrowserRouter as Router } from 'react-router-dom';
+import React from 'react';
 import Topics from './Topics.view.js';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { Route } from 'react-router-dom';
 import { css } from 'emotion';
 
 const Horizontal = css({ label: 'Horizontal', flexDirection: 'row' });
@@ -5423,10 +5437,10 @@ export default UseRouter;
 exports[`react-dom parses react-dom UseSvg 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const Svg = css({
   label: 'Svg',
@@ -5565,11 +5579,11 @@ export default UseSvg;
 exports[`react-dom parses react-dom UseText 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import './Fonts/Montserrat-300';
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import './Fonts/Montserrat-300';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const UseText1 = css({
   label: 'UseText1',
@@ -5619,9 +5633,9 @@ export default UseText;
 exports[`react-dom parses react-dom UseText: react-dom parses react-dom UseText debug 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import './Fonts/Montserrat-300';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import './Fonts/Montserrat-300';
 import { css } from 'emotion';
 
 const UseText1 = css({
@@ -5665,12 +5679,12 @@ export default UseText;
 exports[`react-dom parses react-dom UseTextCustomFont 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
-import ViewsBaseCss from './ViewsBaseCss.view.js';
 import './Fonts/CustomFontNotOnGoogle-300';
 import './Fonts/CustomFontNotOnGoogle-400-italic';
-import { css } from 'emotion';
 import PropTypes from 'prop-types';
+import React from 'react';
+import ViewsBaseCss from './ViewsBaseCss.view.js';
+import { css } from 'emotion';
 
 const Normal = css({
   label: 'Normal',
@@ -5746,10 +5760,10 @@ export default UseTextCustomFont;
 exports[`react-dom parses react-dom UseTextCustomFont: react-dom parses react-dom UseTextCustomFont debug 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
-import ViewsBaseCss from './ViewsBaseCss.view.js';
 import './Fonts/CustomFontNotOnGoogle-300';
 import './Fonts/CustomFontNotOnGoogle-400-italic';
+import React from 'react';
+import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
 
 const Normal = css({
@@ -5819,10 +5833,10 @@ export default UseTextCustomFont;
 exports[`react-dom parses react-dom UseVertical 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const Vertical = css({ label: 'Vertical', backgroundColor: 'red' });
 
@@ -5883,10 +5897,10 @@ export default UseVertical;
 exports[`react-dom parses react-dom ViewNameIsntUsedInStyle 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const ViewNameIsntUsedInStyle1 = css({
   label: 'ViewNameIsntUsedInStyle1',
@@ -5970,10 +5984,10 @@ export default ViewNameIsntUsedInStyle;
 exports[`react-dom parses react-dom When 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
 import { css } from 'emotion';
-import PropTypes from 'prop-types';
 
 const App = css({ label: 'App', flexDirection: 'row' });
 
@@ -6056,9 +6070,9 @@ export default When;
 exports[`react-dom parses react-dom WhenTopLevel 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ViewsBaseCss from './ViewsBaseCss.view.js';
-import PropTypes from 'prop-types';
 
 class WhenTopLevel extends React.Component {
   render() {
@@ -6126,10 +6140,10 @@ export default WhenTopLevel;
 exports[`react-native parses react-native Action 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import SubButton from './SubButton.view.js';
 import { StyleSheet, Text, TouchableWithoutFeedback, View } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({ Vertical: { color: 'red' } });
 
@@ -6195,75 +6209,112 @@ export default Action;
 exports[`react-native parses react-native AnimatedButton 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Animated, StyleSheet, TouchableWithoutFeedback } from 'react-native';
-import PropTypes from 'prop-types';
-const getAnimatedValue = (animatedValue, from, to) =>
-  animatedValue.interpolate({
-    inputRange: [0, 1],
-    outputRange: [from, to],
-  });
-const styles = StyleSheet.create({ Vertical: { backgroundColor: 'red' } });
+import { Spring, Timing } from '@viewstools/animations/native';
+
+const styles = StyleSheet.create({
+  AnimatedButton1: { backgroundColor: 'red' },
+});
 
 class AnimatedButton extends React.Component {
-  animatedValue0 = new Animated.Value(this.props.isOn ? 1 : 0);
-
-  componentDidUpdate(prev) {
-    const { props } = this;
-    if (props.isOn !== prev.isOn) {
-      Animated.spring(this.animatedValue0, {
-        toValue: props.isOn ? 1 : 0,
-        speed: 12,
-        bounciness: 8,
-        delay: 0,
-        useNativeDriver: false,
-      }).start();
-    }
-  }
-
   render() {
     const { context, props } = this;
 
     return (
-      <TouchableWithoutFeedback
-        activeOpacity={0.7}
-        onPress={event =>
-          context.track({
-            block: props['testID'] || 'AnimatedButton',
-            action: 'click',
-            callback: props.onClick,
-            event,
-            props,
-          })
-        }
-        underlayColor=\\"transparent\\"
+      <Spring
+        bounciness={10}
+        speed={1}
+        delay={0}
+        to={{ opacity: props.isOn ? 1 : 0.75 }}
       >
-        <Animated.View
-          testID={\`\${props['testID'] || 'Vertical'}|\${
-            props.isOn ? 'isOn|' : ''
-          }\`}
-          style={[
-            styles.Vertical,
-            {
-              opacity: getAnimatedValue(this.animatedValue0, 0.75, 1),
-              transform: [
-                { translateX: getAnimatedValue(this.animatedValue0, 10, 20) },
-                { rotateX: getAnimatedValue(this.animatedValue0, 10, 20) },
-              ],
-            },
-          ]}
-        >
-          <Animated.Text
-            testID={\`AnimatedButton.Text|\${props.isOn ? 'isOn|' : ''}\`}
-            style={{
-              color: getAnimatedValue(this.animatedValue0, 'red', 'blue'),
-            }}
+        {animatedAnimatedButton => (
+          <Spring
+            bounciness={15}
+            speed={2}
+            delay={0}
+            to={{ translateX: props.isOn ? 20 : 10 }}
           >
-            hey
-          </Animated.Text>
-          {props.children}
-        </Animated.View>
-      </TouchableWithoutFeedback>
+            {animatedAnimatedButton1 => (
+              <Timing
+                curve=\\"easeIn\\"
+                delay={0}
+                duration={150}
+                to={{ rotateX: props.isOn ? 20 : 10 }}
+              >
+                {animatedAnimatedButton2 => (
+                  <Timing
+                    curve=\\"easeInOut\\"
+                    delay={0}
+                    duration={150}
+                    to={{ rotateY: props.isOn ? 20 : 10 }}
+                  >
+                    {animatedAnimatedButton3 => (
+                      <Spring
+                        delay={0}
+                        speed={12}
+                        bounciness={8}
+                        to={{ color: props.isOn ? 'blue' : 'red' }}
+                      >
+                        {animatedText => (
+                          <TouchableWithoutFeedback
+                            activeOpacity={0.7}
+                            onPress={event =>
+                              context.track({
+                                block: props['testID'] || 'AnimatedButton',
+                                action: 'click',
+                                callback: props.onClick,
+                                event,
+                                props,
+                              })
+                            }
+                            underlayColor=\\"transparent\\"
+                          >
+                            <Animated.View
+                              testID={\`\${props['testID'] || 'AnimatedButton'}|\${
+                                props.isOn ? 'isOn|' : ''
+                              }\`}
+                              style={[
+                                styles.AnimatedButton1,
+                                {
+                                  opacity: animatedAnimatedButton.opacity,
+                                  transform: [
+                                    {
+                                      translateX:
+                                        animatedAnimatedButton1.translateX,
+                                    },
+                                    {
+                                      rotateX: animatedAnimatedButton2.rotateX,
+                                    },
+                                    {
+                                      rotateY: animatedAnimatedButton3.rotateY,
+                                    },
+                                  ],
+                                },
+                              ]}
+                            >
+                              <Animated.Text
+                                testID={\`AnimatedButton.Text|\${
+                                  props.isOn ? 'isOn|' : ''
+                                }\`}
+                                style={{ color: animatedText.color }}
+                              >
+                                hey
+                              </Animated.Text>
+                              {props.children}
+                            </Animated.View>
+                          </TouchableWithoutFeedback>
+                        )}
+                      </Spring>
+                    )}
+                  </Timing>
+                )}
+              </Timing>
+            )}
+          </Spring>
+        )}
+      </Spring>
     );
   }
 }
@@ -6288,9 +6339,9 @@ export default AnimatedButton;
 exports[`react-native parses react-native AppRegionDrag 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({
   Vertical: { width: '92%', marginTop: 'auto' },
@@ -6325,9 +6376,9 @@ export default AppRegionDrag;
 exports[`react-native parses react-native BackgroundImage 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Animated, Image, StyleSheet } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({ Horizontal: { flexDirection: 'row' } });
 
@@ -6375,9 +6426,9 @@ export default BackgroundImage;
 exports[`react-native parses react-native Border 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Animated, StyleSheet } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({
   Border1: { borderColor: 'red', borderStyle: 'solid' },
@@ -6473,9 +6524,9 @@ export default Border;
 exports[`react-native parses react-native ClassName 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({ Vertical: { backgroundColor: 'blue' } });
 
@@ -6508,9 +6559,9 @@ export default ClassName;
 exports[`react-native parses react-native Code 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Animated, StyleSheet, View } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({ Vertical: { backgroundColor: 'red' } });
 
@@ -6569,9 +6620,9 @@ export default Code;
 exports[`react-native parses react-native DefaultProps 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Text, View } from 'react-native';
-import PropTypes from 'prop-types';
 
 class DefaultProps extends React.Component {
   render() {
@@ -6615,9 +6666,9 @@ export default DefaultProps;
 exports[`react-native parses react-native Display 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({ Display1: { display: 'block' } });
 
@@ -6647,10 +6698,10 @@ export default Display;
 exports[`react-native parses react-native DynamicStylesApplyToBasicBlocksOnly 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import SomeThing from './SomeThing.view.js';
 import { Animated } from 'react-native';
-import PropTypes from 'prop-types';
 
 class DynamicStylesApplyToBasicBlocksOnly extends React.Component {
   render() {
@@ -6691,9 +6742,9 @@ export default DynamicStylesApplyToBasicBlocksOnly;
 exports[`react-native parses react-native EmptyText 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Text } from 'react-native';
-import PropTypes from 'prop-types';
 
 class EmptyText extends React.Component {
   render() {
@@ -6717,9 +6768,9 @@ export default EmptyText;
 exports[`react-native parses react-native GoTo 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Text, View } from 'react-native';
-import PropTypes from 'prop-types';
 
 class GoTo extends React.Component {
   render() {
@@ -6748,6 +6799,7 @@ export default GoTo;
 exports[`react-native parses react-native Hover 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import {
   Animated,
@@ -6755,7 +6807,6 @@ import {
   TouchableWithoutFeedback,
   View,
 } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({ Text: { color: 'white' } });
 
@@ -6821,9 +6872,9 @@ export default Hover;
 exports[`react-native parses react-native JustText 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Text } from 'react-native';
-import PropTypes from 'prop-types';
 
 class JustText extends React.Component {
   render() {
@@ -6847,10 +6898,10 @@ export default JustText;
 exports[`react-native parses react-native ListOfSomething 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import Something from './Something.view.js';
 import { View } from 'react-native';
-import PropTypes from 'prop-types';
 
 class ListOfSomething extends React.Component {
   render() {
@@ -6893,10 +6944,10 @@ export default ListOfSomething;
 exports[`react-native parses react-native ListWhen 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
 import Card from './Card.view.js';
-import { View } from 'react-native';
 import PropTypes from 'prop-types';
+import React from 'react';
+import { View } from 'react-native';
 
 class ListWhen extends React.Component {
   render() {
@@ -6944,10 +6995,10 @@ export default ListWhen;
 exports[`react-native parses react-native ListWithKey 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
 import Card from './Card.view.js';
-import { View } from 'react-native';
 import PropTypes from 'prop-types';
+import React from 'react';
+import { View } from 'react-native';
 
 class ListWithKey extends React.Component {
   render() {
@@ -6990,11 +7041,11 @@ export default ListWithKey;
 exports[`react-native parses react-native LocalImage 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
-import garfieldPng from './garfield.png';
-import chopperJpg from './chopper.jpg';
-import { Image } from 'react-native';
 import PropTypes from 'prop-types';
+import React from 'react';
+import chopperJpg from './chopper.jpg';
+import garfieldPng from './garfield.png';
+import { Image } from 'react-native';
 
 class LocalImage extends React.Component {
   render() {
@@ -7025,10 +7076,10 @@ export default LocalImage;
 exports[`react-native parses react-native LocalImageSvg 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import chopperSvg from './chopper.svg';
 import { Image, StyleSheet } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({ LocalImageSvg1: { width: 50 } });
 
@@ -7066,9 +7117,9 @@ export default LocalImageSvg;
 exports[`react-native parses react-native LocalOrRemoteImageWhenCode 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Image } from 'react-native';
-import PropTypes from 'prop-types';
 
 class LocalOrRemoteImageWhenCode extends React.Component {
   render() {
@@ -7105,11 +7156,11 @@ export default LocalOrRemoteImageWhenCode;
 exports[`react-native parses react-native Locals 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
-import { Text, View } from 'react-native';
-import PropTypes from 'prop-types';
-import { Subscribe } from 'unstated';
 import LocalContainer from './LocalContainer.view.js';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Subscribe } from 'unstated';
+import { Text, View } from 'react-native';
 
 const TextLocal = {
   es: 'Hola',
@@ -7162,9 +7213,9 @@ export default Locals;
 exports[`react-native parses react-native LocalsFormat 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Text, View } from 'react-native';
-import PropTypes from 'prop-types';
 
 const currencyOptions = { style: 'currency', currency: 'USD' };
 const currencyFormatters = {
@@ -7247,9 +7298,9 @@ export default LocalsFormat;
 exports[`react-native parses react-native NameIsType 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Text } from 'react-native';
-import PropTypes from 'prop-types';
 
 class NameIsType extends React.Component {
   render() {
@@ -7273,9 +7324,9 @@ export default NameIsType;
 exports[`react-native parses react-native NegativeNumber 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { StyleSheet, Text } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({ Text: { marginTop: -10 } });
 
@@ -7305,12 +7356,12 @@ export default NegativeNumber;
 exports[`react-native parses react-native NestedRoutes 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
+import Topic from './Topic.view.js';
 import { Link } from 'react-router-native';
 import { Route } from 'react-router-native';
-import Topic from './Topic.view.js';
 import { Text, View } from 'react-native';
-import PropTypes from 'prop-types';
 
 class NestedRoutes extends React.Component {
   render() {
@@ -7350,9 +7401,9 @@ export default NestedRoutes;
 exports[`react-native parses react-native Scope 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Text } from 'react-native';
-import PropTypes from 'prop-types';
 
 class Scope extends React.Component {
   render() {
@@ -7399,9 +7450,9 @@ export default Scope;
 exports[`react-native parses react-native ScopeOnCustomView 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
 import Button from './Button.view.js';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 class ScopeOnCustomView extends React.Component {
   render() {
@@ -7442,9 +7493,9 @@ export default ScopeOnCustomView;
 exports[`react-native parses react-native ScopePopup 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Text, TouchableWithoutFeedback, View } from 'react-native';
-import PropTypes from 'prop-types';
 
 class ScopePopup extends React.Component {
   render() {
@@ -7497,9 +7548,9 @@ export default ScopePopup;
 exports[`react-native parses react-native ScopePopup2 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Text, TouchableWithoutFeedback, View } from 'react-native';
-import PropTypes from 'prop-types';
 
 class ScopePopup2 extends React.Component {
   render() {
@@ -7565,10 +7616,10 @@ export default ScopePopup2;
 exports[`react-native parses react-native ScrollableList 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
 import Card from './Card.view.js';
-import { Animated, FlatList, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
+import React from 'react';
+import { Animated, FlatList, StyleSheet } from 'react-native';
 
 const styles = StyleSheet.create({
   ScrollableList1ContentContainer: { paddingBottom: 200 },
@@ -7623,9 +7674,9 @@ export default ScrollableList;
 exports[`react-native parses react-native Shadow 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Animated, StyleSheet, View } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({
   BoxShadow: {
@@ -7705,9 +7756,9 @@ export default Shadow;
 exports[`react-native parses react-native SomeMissingStyle 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Animated, StyleSheet, TouchableWithoutFeedback } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({
   WindowControl: {
@@ -7770,10 +7821,10 @@ export default SomeMissingStyle;
 exports[`react-native parses react-native Teleport 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router-native';
 import { StyleSheet, Text, View } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({ Horizontal: { flexDirection: 'row' } });
 
@@ -7810,10 +7861,10 @@ export default Teleport;
 exports[`react-native parses react-native TestIds 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
 import External from './External.view.js';
-import { Text, View } from 'react-native';
 import PropTypes from 'prop-types';
+import React from 'react';
+import { Text, View } from 'react-native';
 
 class TestIds extends React.Component {
   render() {
@@ -7845,9 +7896,9 @@ export default TestIds;
 exports[`react-native parses react-native TextInterpolation 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Text, View } from 'react-native';
-import PropTypes from 'prop-types';
 
 class TextInterpolation extends React.Component {
   render() {
@@ -7899,9 +7950,9 @@ export default TextInterpolation;
 exports[`react-native parses react-native Transform 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Animated, StyleSheet, View } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({
   Transform1: {
@@ -7967,9 +8018,9 @@ export default Transform;
 exports[`react-native parses react-native UseCaptureEmail 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { StyleSheet, TextInput } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({
   Email: {
@@ -8029,9 +8080,9 @@ export default UseCaptureEmail;
 exports[`react-native parses react-native UseCaptureFile 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
 import CaptureFile from './CaptureFile.view.js';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 class UseCaptureFile extends React.Component {
   constructor(props) {
@@ -8072,9 +8123,9 @@ export default UseCaptureFile;
 exports[`react-native parses react-native UseCaptureNumber 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { TextInput } from 'react-native';
-import PropTypes from 'prop-types';
 
 class UseCaptureNumber extends React.Component {
   constructor(props) {
@@ -8115,9 +8166,9 @@ export default UseCaptureNumber;
 exports[`react-native parses react-native UseCapturePhone 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { TextInput } from 'react-native';
-import PropTypes from 'prop-types';
 
 class UseCapturePhone extends React.Component {
   constructor(props) {
@@ -8158,9 +8209,9 @@ export default UseCapturePhone;
 exports[`react-native parses react-native UseCaptureSecure 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { TextInput } from 'react-native';
-import PropTypes from 'prop-types';
 
 class UseCaptureSecure extends React.Component {
   constructor(props) {
@@ -8201,11 +8252,11 @@ export default UseCaptureSecure;
 exports[`react-native parses react-native UseCaptureText 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
-import { TextInput } from 'react-native';
-import PropTypes from 'prop-types';
-import { Subscribe } from 'unstated';
 import LocalContainer from './LocalContainer.view.js';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Subscribe } from 'unstated';
+import { TextInput } from 'react-native';
 
 const TextLocal = {
   es: 'Escriba sus comentarios aqui...',
@@ -8256,9 +8307,9 @@ export default UseCaptureText;
 exports[`react-native parses react-native UseCaptureTextArea 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { TextInput } from 'react-native';
-import PropTypes from 'prop-types';
 
 class UseCaptureTextArea extends React.Component {
   constructor(props) {
@@ -8300,9 +8351,9 @@ export default UseCaptureTextArea;
 exports[`react-native parses react-native UseCaptureTextManagedFromOutside 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { TextInput } from 'react-native';
-import PropTypes from 'prop-types';
 
 class UseCaptureTextManagedFromOutside extends React.Component {
   constructor(props) {
@@ -8350,9 +8401,9 @@ export default UseCaptureTextManagedFromOutside;
 exports[`react-native parses react-native UseHorizontal 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({
   Horizontal: {
@@ -8392,9 +8443,9 @@ export default UseHorizontal;
 exports[`react-native parses react-native UseImage 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Image } from 'react-native';
-import PropTypes from 'prop-types';
 
 class UseImage extends React.Component {
   render() {
@@ -8429,14 +8480,14 @@ export default UseImage;
 exports[`react-native parses react-native UseRouter 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react';
 import About from './About.view.js';
 import Home from './Home.view.js';
-import { Route } from 'react-router-native';
-import { NativeRouter as Router } from 'react-router-native';
-import Topics from './Topics.view.js';
-import { StyleSheet, View } from 'react-native';
 import PropTypes from 'prop-types';
+import React from 'react';
+import Topics from './Topics.view.js';
+import { NativeRouter as Router } from 'react-router-native';
+import { Route } from 'react-router-native';
+import { StyleSheet, View } from 'react-native';
 
 const styles = StyleSheet.create({ Horizontal: { flexDirection: 'row' } });
 
@@ -8501,6 +8552,7 @@ export default UseRouter;
 exports[`react-native parses react-native UseSvg 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import Svg, {
   Circle as SvgCircle,
@@ -8508,7 +8560,6 @@ import Svg, {
   Path as SvgPath,
   Text as SvgText,
 } from 'react-native-svg';
-import PropTypes from 'prop-types';
 
 class UseSvg extends React.Component {
   render() {
@@ -8551,9 +8602,9 @@ export default UseSvg;
 exports[`react-native parses react-native UseText 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { StyleSheet, Text } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({
   UseText1: { fontFamily: 'Montserrat-300', fontSize: 16, lineHeight: 24 },
@@ -8597,9 +8648,9 @@ export default UseText;
 exports[`react-native parses react-native UseTextCustomFont 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({
   Normal: {
@@ -8670,9 +8721,9 @@ export default UseTextCustomFont;
 exports[`react-native parses react-native UseVertical 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({ Vertical: { backgroundColor: 'red' } });
 
@@ -8705,9 +8756,9 @@ export default UseVertical;
 exports[`react-native parses react-native ViewNameIsntUsedInStyle 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Animated, StyleSheet } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({ ViewNameIsntUsedInStyle1: { zIndex: 5 } });
 
@@ -8746,9 +8797,9 @@ export default ViewNameIsntUsedInStyle;
 exports[`react-native parses react-native When 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({ App: { flexDirection: 'row' } });
 
@@ -8787,9 +8838,9 @@ export default When;
 exports[`react-native parses react-native WhenTopLevel 1`] = `
 Object {
   "code": "/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Text } from 'react-native';
-import PropTypes from 'prop-types';
 
 class WhenTopLevel extends React.Component {
   render() {

--- a/__tests__/__snapshots__/react.js.snap
+++ b/__tests__/__snapshots__/react.js.snap
@@ -19,7 +19,7 @@ Object {
 
 module.exports = {
   Text: get('AnimatedButton.Text', 'isOn'),
-  Vertical: get('AnimatedButton.Vertical', 'isOn'),
+  _top: get('AnimatedButton', 'isOn'),
 };
 ",
 }
@@ -803,8 +803,8 @@ const getAnimatedValue = (animatedValue, from, to) =>
     outputRange: [from, to],
   });
 
-const Vertical = css({
-  label: 'Vertical',
+const AnimatedButton1 = css({
+  label: 'AnimatedButton1',
   backgroundColor: 'red',
   transition: 'transform 150ms ease-in 0ms',
   willChange: 'opacity, transform',
@@ -820,57 +820,60 @@ const Text = css({
 });
 
 class AnimatedButton extends React.Component {
-  animatedValue0 = new Animated.Value(this.props.isOn ? 1 : 0);
-
-  componentDidUpdate(prev) {
-    const { props } = this;
-    if (props.isOn !== prev.isOn) {
-      Animated.spring(this.animatedValue0, {
-        toValue: props.isOn ? 1 : 0,
-        speed: 12,
-        bounciness: 8,
-        delay: 0,
-        useNativeDriver: false,
-      }).start();
-    }
-  }
-
   render() {
     const { context, props } = this;
 
     return (
-      <Animated.button
-        data-test-id={\`\${props['data-test-id'] || 'Vertical'}|\${
-          props.isOn ? 'isOn|' : ''
-        }\`}
-        onClick={event =>
-          context.track({
-            block: props['data-test-id'] || 'AnimatedButton',
-            action: 'click',
-            callback: props.onClick,
-            event,
-            props,
-          })
-        }
-        style={{
-          '--opacity': getAnimatedValue(this.animatedValue0, 0.75, 1),
-          '--translateX': getAnimatedValue(this.animatedValue0, '10px', '20px'),
-          '--translateY': \`\${props.isOn ? 30 : 0}px\`,
-          '--rotateX': \`\${props.isOn ? 20 : 10}deg\`,
-        }}
-        className={\`views-block \${Vertical}\`}
+      <AnimatedSpringComponent
+        config={{ bounciness: 10, speed: 1 }}
+        delay={0}
+        to={{ opacity: props.isOn ? 1 : 0.75 }}
       >
-        <span
-          data-test-id={\`AnimatedButton.Text|\${props.isOn ? 'isOn|' : ''}\`}
-          style={{
-            '--color': getAnimatedValue(this.animatedValue0, 'red', 'blue'),
-          }}
-          className={\`views-block \${Text}\`}
+        animatedAnimatedButton => (<AnimatedSpringComponent
+          config={{ bounciness: 15, speed: 2 }}
+          delay={0}
+          to={{ translateX: props.isOn ? 20 : 10 }}
         >
-          hey
-        </span>
-        {props.children}
-      </Animated.button>
+          animatedAnimatedButton => (<AnimatedSpringComponent
+            config={{ bounciness: 8, speed: 12 }}
+            delay={0}
+            to={{ color: props.isOn ? 'blue' : 'red' }}
+          >
+            animatedText => (<Animated.button
+              data-test-id={\`\${props['data-test-id'] || 'AnimatedButton'}|\${
+                props.isOn ? 'isOn|' : ''
+              }\`}
+              onClick={event =>
+                context.track({
+                  block: props['data-test-id'] || 'AnimatedButton',
+                  action: 'click',
+                  callback: props.onClick,
+                  event,
+                  props,
+                })
+              }
+              style={{
+                '--opacity': animatedAnimatedButton.opacity,
+                '--translateX': animatedAnimatedButton.translateX,
+                '--translateY': \`\${props.isOn ? 30 : 0}px\`,
+                '--rotateX': \`\${props.isOn ? 20 : 10}deg\`,
+              }}
+              className={\`views-block \${AnimatedButton1}\`}
+            >
+              <span
+                data-test-id={\`AnimatedButton.Text|\${
+                  props.isOn ? 'isOn|' : ''
+                }\`}
+                style={{ '--color': animatedText.color }}
+                className={\`views-block \${Text}\`}
+              >
+                hey
+              </span>
+              {props.children}
+            </Animated.button>)}
+          </AnimatedSpringComponent>)}
+        </AnimatedSpringComponent>)}
+      </AnimatedSpringComponent>
     );
   }
 }
@@ -905,8 +908,8 @@ const getAnimatedValue = (animatedValue, from, to) =>
     outputRange: [from, to],
   });
 
-const Vertical = css({
-  label: 'Vertical',
+const AnimatedButton1 = css({
+  label: 'AnimatedButton1',
   backgroundColor: 'red',
   transition: 'transform 150ms ease-in 0ms',
   willChange: 'opacity, transform',
@@ -922,49 +925,52 @@ const Text = css({
 });
 
 class AnimatedButton extends React.Component {
-  animatedValue0 = new Animated.Value(this.props.isOn ? 1 : 0);
-
-  componentDidUpdate(prev) {
-    const { props } = this;
-    if (props.isOn !== prev.isOn) {
-      Animated.spring(this.animatedValue0, {
-        toValue: props.isOn ? 1 : 0,
-        speed: 12,
-        bounciness: 8,
-        delay: 0,
-        useNativeDriver: false,
-      }).start();
-    }
-  }
-
   render() {
     const { props } = this;
 
     return (
-      <Animated.button
-        data-test-id={\`\${props['data-test-id'] || 'Vertical'}|\${
-          props.isOn ? 'isOn|' : ''
-        }\`}
-        onClick={props.onClick}
-        style={{
-          '--opacity': getAnimatedValue(this.animatedValue0, 0.75, 1),
-          '--translateX': getAnimatedValue(this.animatedValue0, '10px', '20px'),
-          '--translateY': \`\${props.isOn ? 30 : 0}px\`,
-          '--rotateX': \`\${props.isOn ? 20 : 10}deg\`,
-        }}
-        className={\`views-block \${Vertical}\`}
+      <AnimatedSpringComponent
+        config={{ bounciness: 10, speed: 1 }}
+        delay={0}
+        to={{ opacity: props.isOn ? 1 : 0.75 }}
       >
-        <span
-          data-test-id={\`AnimatedButton.Text|\${props.isOn ? 'isOn|' : ''}\`}
-          style={{
-            '--color': getAnimatedValue(this.animatedValue0, 'red', 'blue'),
-          }}
-          className={\`views-block \${Text}\`}
+        animatedAnimatedButton => (<AnimatedSpringComponent
+          config={{ bounciness: 15, speed: 2 }}
+          delay={0}
+          to={{ translateX: props.isOn ? 20 : 10 }}
         >
-          hey
-        </span>
-        {props.children}
-      </Animated.button>
+          animatedAnimatedButton => (<AnimatedSpringComponent
+            config={{ bounciness: 8, speed: 12 }}
+            delay={0}
+            to={{ color: props.isOn ? 'blue' : 'red' }}
+          >
+            animatedText => (<Animated.button
+              data-test-id={\`\${props['data-test-id'] || 'AnimatedButton'}|\${
+                props.isOn ? 'isOn|' : ''
+              }\`}
+              onClick={props.onClick}
+              style={{
+                '--opacity': animatedAnimatedButton.opacity,
+                '--translateX': animatedAnimatedButton.translateX,
+                '--translateY': \`\${props.isOn ? 30 : 0}px\`,
+                '--rotateX': \`\${props.isOn ? 20 : 10}deg\`,
+              }}
+              className={\`views-block \${AnimatedButton1}\`}
+            >
+              <span
+                data-test-id={\`AnimatedButton.Text|\${
+                  props.isOn ? 'isOn|' : ''
+                }\`}
+                style={{ '--color': animatedText.color }}
+                className={\`views-block \${Text}\`}
+              >
+                hey
+              </span>
+              {props.children}
+            </Animated.button>)}
+          </AnimatedSpringComponent>)}
+        </AnimatedSpringComponent>)}
+      </AnimatedSpringComponent>
     );
   }
 }

--- a/__tests__/__snapshots__/react.js.snap
+++ b/__tests__/__snapshots__/react.js.snap
@@ -810,8 +810,9 @@ const AnimatedButton1 = css({
 const Text = css({
   label: 'Text',
 
-  willChange: 'color',
+  willChange: 'color, font-size',
   color: 'var(--color)',
+  fontSize: 'var(--fontSize)',
 });
 
 class AnimatedButton extends React.Component {
@@ -840,7 +841,10 @@ class AnimatedButton extends React.Component {
                 delay={0}
                 speed={12}
                 bounciness={8}
-                to={{ color: props.isOn ? 'blue' : 'red' }}
+                to={{
+                  color: props.isOn ? 'blue' : 'red',
+                  fontSize: \`\${props.isOn ? 18 : 12}px\`,
+                }}
               >
                 {animatedText => (
                   <animated.button
@@ -857,7 +861,7 @@ class AnimatedButton extends React.Component {
                     }
                     style={{
                       '--opacity': animatedAnimatedButton.opacity,
-                      '--translateX': animatedAnimatedButton1.translateX,
+                      '--translateX': animatedAnimatedButton.translateX,
                       '--translateY': \`\${props.isOn ? 30 : 0}px\`,
                       '--rotateX': \`\${props.isOn ? 20 : 10}deg\`,
                       '--rotateY': \`\${props.isOn ? 20 : 10}deg\`,
@@ -868,7 +872,10 @@ class AnimatedButton extends React.Component {
                       data-test-id={\`AnimatedButton.Text|\${
                         props.isOn ? 'isOn|' : ''
                       }\`}
-                      style={{ '--color': animatedText.color }}
+                      style={{
+                        '--color': animatedText.color,
+                        '--fontSize': animatedText.fontSize,
+                      }}
                       className={\`views-block \${Text}\`}
                     >
                       hey
@@ -922,8 +929,9 @@ const AnimatedButton1 = css({
 const Text = css({
   label: 'Text',
 
-  willChange: 'color',
+  willChange: 'color, font-size',
   color: 'var(--color)',
+  fontSize: 'var(--fontSize)',
 });
 
 class AnimatedButton extends React.Component {
@@ -952,7 +960,10 @@ class AnimatedButton extends React.Component {
                 delay={0}
                 speed={12}
                 bounciness={8}
-                to={{ color: props.isOn ? 'blue' : 'red' }}
+                to={{
+                  color: props.isOn ? 'blue' : 'red',
+                  fontSize: \`\${props.isOn ? 18 : 12}px\`,
+                }}
               >
                 {animatedText => (
                   <animated.button
@@ -961,7 +972,7 @@ class AnimatedButton extends React.Component {
                     onClick={props.onClick}
                     style={{
                       '--opacity': animatedAnimatedButton.opacity,
-                      '--translateX': animatedAnimatedButton1.translateX,
+                      '--translateX': animatedAnimatedButton.translateX,
                       '--translateY': \`\${props.isOn ? 30 : 0}px\`,
                       '--rotateX': \`\${props.isOn ? 20 : 10}deg\`,
                       '--rotateY': \`\${props.isOn ? 20 : 10}deg\`,
@@ -972,7 +983,10 @@ class AnimatedButton extends React.Component {
                       data-test-id={\`AnimatedButton.Text|\${
                         props.isOn ? 'isOn|' : ''
                       }\`}
-                      style={{ '--color': animatedText.color }}
+                      style={{
+                        '--color': animatedText.color,
+                        '--fontSize': animatedText.fontSize,
+                      }}
                       className={\`views-block \${Text}\`}
                     >
                       hey
@@ -6255,7 +6269,10 @@ class AnimatedButton extends React.Component {
                         delay={0}
                         speed={12}
                         bounciness={8}
-                        to={{ color: props.isOn ? 'blue' : 'red' }}
+                        to={{
+                          color: props.isOn ? 'blue' : 'red',
+                          fontSize: props.isOn ? 18 : 12,
+                        }}
                       >
                         {animatedText => (
                           <TouchableWithoutFeedback
@@ -6282,14 +6299,10 @@ class AnimatedButton extends React.Component {
                                   transform: [
                                     {
                                       translateX:
-                                        animatedAnimatedButton1.translateX,
+                                        animatedAnimatedButton.translateX,
                                     },
-                                    {
-                                      rotateX: animatedAnimatedButton2.rotateX,
-                                    },
-                                    {
-                                      rotateY: animatedAnimatedButton3.rotateY,
-                                    },
+                                    { rotateX: animatedAnimatedButton.rotateX },
+                                    { rotateY: animatedAnimatedButton.rotateY },
                                   ],
                                 },
                               ]}
@@ -6298,7 +6311,10 @@ class AnimatedButton extends React.Component {
                                 testID={\`AnimatedButton.Text|\${
                                   props.isOn ? 'isOn|' : ''
                                 }\`}
-                                style={{ color: animatedText.color }}
+                                style={{
+                                  color: animatedText.color,
+                                  fontSize: animatedText.fontSize,
+                                }}
                               >
                                 hey
                               </Animated.Text>

--- a/__tests__/views/AnimatedButton.view
+++ b/__tests__/views/AnimatedButton.view
@@ -4,12 +4,14 @@ opacity 0.75
 translateX 10
 translateY 0
 rotateX 10
+rotateY 10
 onClick <
 when <isOn
 opacity 1 spring bounciness 10 speed 1
 translateX 20 spring bounciness 15 speed 2
 translateY 30
 rotateX 20 easeIn
+rotateY 20 easeInOut
 Text
 color red
 text hey

--- a/__tests__/views/AnimatedButton.view
+++ b/__tests__/views/AnimatedButton.view
@@ -15,5 +15,7 @@ rotateY 20 easeInOut
 Text
 color red
 text hey
+fontSize 12
 when <isOn
 color blue spring
+fontSize 18 spring

--- a/__tests__/views/AnimatedButton.view
+++ b/__tests__/views/AnimatedButton.view
@@ -1,4 +1,4 @@
-Vertical
+AnimatedButton Vertical
 backgroundColor red
 opacity 0.75
 translateX 10

--- a/__tests__/views/AnimatedButton.view
+++ b/__tests__/views/AnimatedButton.view
@@ -6,8 +6,8 @@ translateY 0
 rotateX 10
 onClick <
 when <isOn
-opacity 1 spring
-translateX 20 spring
+opacity 1 spring bounciness 10 speed 1
+translateX 20 spring bounciness 15 speed 2
 translateY 30
 rotateX 20 easeIn
 Text

--- a/morph/react-dom.js
+++ b/morph/react-dom.js
@@ -35,6 +35,7 @@ export default ({
   }
 
   const state = {
+    animations: [],
     captures: [],
     cssDynamic: false,
     cssStatic: false,

--- a/morph/react-dom.js
+++ b/morph/react-dom.js
@@ -35,7 +35,7 @@ export default ({
   }
 
   const state = {
-    animations: [],
+    animations: {},
     captures: [],
     cssDynamic: false,
     cssStatic: false,

--- a/morph/react-dom/get-block-name.js
+++ b/morph/react-dom/get-block-name.js
@@ -66,8 +66,8 @@ export default (node, parent, state) => {
       break
   }
 
-  if (node.isAnimatedReallyAnimated) {
-    return `Animated.${name}`
+  if (node.hasSpringAnimation) {
+    return `animated.${name}`
   }
 
   return name

--- a/morph/react-dom/properties-style.js
+++ b/morph/react-dom/properties-style.js
@@ -34,7 +34,7 @@ export function leave(node, parent, state) {
 
   if (node.isAnimated && hasSpringAnimation(node)) {
     state.isAnimated = true
-    state.animations = state.animations.concat(node.animations)
+    state.animations[node.id] = node.animations
     state.scopes = node.scopes
   }
 

--- a/morph/react-dom/properties-style.js
+++ b/morph/react-dom/properties-style.js
@@ -7,11 +7,8 @@ import {
   getAnimatedStyles,
   getDynamicStyles,
   getTimingProps,
-  hasAnimatedChild,
   hasKeys,
   hasKeysInChildren,
-  hasSpringAnimation,
-  hasTimingAnimation,
 } from '../utils.js'
 import toSlugCase from 'to-slug-case'
 import uniq from 'array-uniq'
@@ -28,11 +25,7 @@ export function leave(node, parent, state) {
     scopedUnderParent = scopedUnderParent.styleName
   }
 
-  if (hasAnimatedChild(node) && hasSpringAnimation(node)) {
-    state.hasAnimatedChild = true
-  }
-
-  if (node.isAnimated && hasSpringAnimation(node)) {
+  if (node.hasSpringAnimation) {
     state.isAnimated = true
     state.animations[node.id] = node.animations
     state.scopes = node.scopes
@@ -76,7 +69,7 @@ export function leave(node, parent, state) {
     label: '${id}',
     ${cssStatic ? `${cssStatic}, ` : ''}${cssDynamic}})`
 
-    if (hasSpringAnimation(node)) {
+    if (node.hasSpringAnimation) {
       state.render.push(
         ` style={{${getAnimatedStyles(
           node,
@@ -106,7 +99,7 @@ export function leave(node, parent, state) {
 }
 
 const asAnimatedCss = node => {
-  if (hasTimingAnimation(node)) {
+  if (node.hasTimingAnimation) {
     const transition = uniq(getTimingProps(node).map(makeTransition)).join(', ')
 
     return `\ntransition: '${transition}',\nwillChange: '${getUniqueNames(

--- a/morph/react-dom/properties-style.js
+++ b/morph/react-dom/properties-style.js
@@ -27,6 +27,7 @@ export function leave(node, parent, state) {
 
   if (node.hasSpringAnimation) {
     state.isAnimated = true
+    state.hasSpringAnimation = true
     state.animations[node.id] = node.animations
     state.scopes = node.scopes
   }

--- a/morph/react-dom/properties-style.js
+++ b/morph/react-dom/properties-style.js
@@ -34,7 +34,7 @@ export function leave(node, parent, state) {
 
   if (node.isAnimated && hasSpringAnimation(node)) {
     state.isAnimated = true
-    state.animations = node.animations
+    state.animations = state.animations.concat(node.animations)
     state.scopes = node.scopes
   }
 

--- a/morph/react-native.js
+++ b/morph/react-native.js
@@ -37,6 +37,7 @@ export default ({
   }
 
   const state = {
+    animations: [],
     captures: [],
     images: [],
     getFont,

--- a/morph/react-native.js
+++ b/morph/react-native.js
@@ -2,7 +2,6 @@ import * as visitor from './react-native/block.js'
 import getStyleForProperty from './react-native/get-style-for-property.js'
 import getStyles from './react-native/get-styles.js'
 import getValueForProperty from './react-native/get-value-for-property.js'
-import maybeUsesAnimated from './react-native/maybe-uses-animated.js'
 import maybeUsesTextInput from './react-native/maybe-uses-text-input.js'
 import maybeUsesRouter from './react-native/maybe-uses-router.js'
 import maybeUsesStyleSheet from './react-native/maybe-uses-style-sheet.js'
@@ -76,7 +75,6 @@ export default ({
 
   walk(parsed.views[0], visitor, state)
 
-  maybeUsesAnimated(state)
   maybeUsesTextInput(state)
   maybeUsesRouter(state)
   maybeUsesStyleSheet(state)

--- a/morph/react-native.js
+++ b/morph/react-native.js
@@ -37,7 +37,7 @@ export default ({
   }
 
   const state = {
-    animations: [],
+    animations: {},
     captures: [],
     images: [],
     getFont,

--- a/morph/react-native/maybe-uses-animated.js
+++ b/morph/react-native/maybe-uses-animated.js
@@ -1,5 +1,0 @@
-export default state => {
-  if (state.hasAnimatedChild || state.isAnimated) {
-    state.uses.push('Animated')
-  }
-}

--- a/morph/react-native/properties-style.js
+++ b/morph/react-native/properties-style.js
@@ -49,7 +49,7 @@ export const leave = (node, parent, state) => {
     const animated = getAnimatedStyles(node, state.isReactNative)
     style = style ? `[${style},{${animated}}]` : `{${animated}}`
     state.isAnimated = true
-    state.animations = node.animations
+    state.animations = state.animations.concat(node.animations)
     state.scopes = node.scopes
   }
 

--- a/morph/react-native/properties-style.js
+++ b/morph/react-native/properties-style.js
@@ -49,7 +49,7 @@ export const leave = (node, parent, state) => {
     const animated = getAnimatedStyles(node, state.isReactNative)
     style = style ? `[${style},{${animated}}]` : `{${animated}}`
     state.isAnimated = true
-    state.animations = state.animations.concat(node.animations)
+    state.animations[node.id] = node.animations
     state.scopes = node.scopes
   }
 

--- a/morph/react-native/properties-style.js
+++ b/morph/react-native/properties-style.js
@@ -49,6 +49,13 @@ export const leave = (node, parent, state) => {
     style = style ? `[${style},{${animated}}]` : `{${animated}}`
     state.isAnimated = true
     state.animations[node.id] = node.animations
+    if (node.hasSpringAnimation) {
+      state.hasSpringAnimation = true
+    }
+
+    if (node.hasTimingAnimation) {
+      state.hasTimingAnimation = true
+    }
     state.scopes = node.scopes
   }
 

--- a/morph/react-native/properties-style.js
+++ b/morph/react-native/properties-style.js
@@ -3,7 +3,6 @@ import {
   createId,
   getAnimatedStyles,
   getObjectAsString,
-  hasAnimatedChild,
   // TODO: Think of a better name 🙈
   getNonAnimatedDynamicStyles,
   hasPaddingProp,
@@ -67,10 +66,6 @@ export const leave = (node, parent, state) => {
       const dynamic = getObjectAsString(dynamicStyles)
       style = style ? `[${style},${dynamic}]` : dynamic
     }
-  }
-
-  if (hasAnimatedChild(node)) {
-    state.hasAnimatedChild = true
   }
 
   if (style) {

--- a/morph/react/get-animated-value.js
+++ b/morph/react/get-animated-value.js
@@ -1,8 +1,0 @@
-export default ({ hasAnimatedChild, isAnimated }) =>
-  hasAnimatedChild || isAnimated
-    ? `const getAnimatedValue = (animatedValue, from, to) =>
-    animatedValue.interpolate({
-      inputRange: [0, 1],
-      outputRange: [from, to],
-    })`
-    : ''

--- a/morph/react/get-body.js
+++ b/morph/react/get-body.js
@@ -61,6 +61,7 @@ export default ({ state, name }) => {
     state.isAnimated || state.hasAnimatedChild
       ? `${state.animations
           .map((animation, index) => {
+            console.log(index, 'animation', animation)
             return isNewScope(state, animation, index)
               ? composeValues(
                   state,

--- a/morph/react/get-body.js
+++ b/morph/react/get-body.js
@@ -74,7 +74,6 @@ export default ({ state, name }) => {
         const useNativeDriver = state.isReactNative
           ? false // !Object.keys(item.props).some(canUseNativeDriver)
           : true
-
         animatedOpen.push(
           `<${tag} ${
             useNativeDriver ? 'native' : ''
@@ -97,7 +96,9 @@ export default ({ state, name }) => {
       maybeState ? 'state' : ''
     } } = this
     ${maybeChildrenArray}
-    return (${animatedOpen.join('')}${render}${animatedClose.join('')})
+    return (${animatedOpen.join('')}${render}${animatedClose
+      .reverse()
+      .join('')})
   }
 }`
   } else {

--- a/morph/react/get-body.js
+++ b/morph/react/get-body.js
@@ -30,16 +30,19 @@ export default ({ state, name }) => {
 
     Object.keys(state.animations).forEach(blockId => {
       Object.values(state.animations[blockId]).forEach(item => {
-        const { curve, delay, ...configValues } = item.animation.properties
+        const { curve, ...configValues } = item.animation.properties
 
         if (!state.isReactNative && curve !== 'spring') return
 
-        // react-spring only exposes Spring as a component,
-        // you can configure the Timing animations with the TimingAnimation bit
-        const tag = 'Spring' // toPascalCase(curve)
-        const config = Object.entries(configValues)
-          .map(([key, value]) => `${key}: ${value}`)
-          .join(',')
+        const tag = curve === 'spring' ? 'Spring' : 'Timing'
+        let config = Object.entries(configValues)
+          .map(([key, value]) => `${key}={${value}}`)
+          .join(' ')
+
+        if (curve !== 'spring') {
+          config = `curve="${curve}" ${config}`
+        }
+
         const to = Object.values(item.props)
           .map(prop => {
             prop.scopes.reverse()
@@ -72,12 +75,10 @@ export default ({ state, name }) => {
           ? false // !Object.keys(item.props).some(canUseNativeDriver)
           : true
 
-        const impl = curve === 'spring' ? 'SpringAnimation' : 'TimingAnimation'
-
         animatedOpen.push(
-          `<${tag} impl={${impl}} ${
+          `<${tag} ${
             useNativeDriver ? 'native' : ''
-          } config={{${config}}} delay={${delay}} to={{${to}}}>{animated${blockId}${
+          } ${config} to={{${to}}}>{animated${blockId}${
             item.index > 0 ? item.index : ''
           } => (`
         )

--- a/morph/react/get-dependencies.js
+++ b/morph/react/get-dependencies.js
@@ -73,22 +73,19 @@ export default (state, getImport) => {
   }
 
   if (state.isAnimated) {
-    dependencies.push(
-      `import { ${
-        state.isReactNative ? '' : 'animated, '
-      }Spring } from "react-spring/dist/${
-        state.isReactNative ? 'native' : 'web'
-      }"`
-    )
-    dependencies.push(
-      `import SpringAnimation from "@viewstools/react-spring-animation-${
-        state.isReactNative ? 'native' : 'web'
-      }"`
-    )
+    const animations = [
+      !state.isReactNative && 'animated',
+      state.hasSpringAnimation && 'Spring',
+      state.hasTimingAnimation && state.isReactNative && 'Timing',
+    ].filter(Boolean)
 
-    // dependencies.push(
-    //   `const Animated = { View: animated(View), Text: animated(Text) }`
-    // )
+    if (animations.length > 0) {
+      dependencies.push(
+        `import { ${animations.join(', ')} } from "@viewstools/animations/${
+          state.isReactNative ? 'native' : 'dom'
+        }"`
+      )
+    }
   }
 
   if (usesSvg.length > 0) {

--- a/morph/react/get-dependencies.js
+++ b/morph/react/get-dependencies.js
@@ -29,7 +29,8 @@ export default (state, getImport) => {
     }
   }
 
-  const dependencies = []
+  const dependencies = [`import React from 'react'`]
+
   state.uses.sort().forEach(d => {
     if (state.isReactNative && NATIVE.includes(d)) {
       useNative(d)
@@ -71,8 +72,23 @@ export default (state, getImport) => {
     dependencies.push('import { css } from "emotion"')
   }
 
-  if (state.isAnimated && !state.isReactNative) {
-    dependencies.push('import Animated from "animated/lib/targets/react-dom"')
+  if (state.isAnimated) {
+    dependencies.push(
+      `import { ${
+        state.isReactNative ? '' : 'animated, '
+      }Spring } from "react-spring/dist/${
+        state.isReactNative ? 'native' : 'web'
+      }"`
+    )
+    dependencies.push(
+      `import SpringAnimation from "@viewstools/react-spring-animation-${
+        state.isReactNative ? 'native' : 'web'
+      }"`
+    )
+
+    // dependencies.push(
+    //   `const Animated = { View: animated(View), Text: animated(Text) }`
+    // )
   }
 
   if (usesSvg.length > 0) {
@@ -93,5 +109,8 @@ export default (state, getImport) => {
     dependencies.push(getImport('LocalContainer'))
   }
 
-  return dependencies.join('\n')
+  return dependencies
+    .filter(Boolean)
+    .sort()
+    .join('\n')
 }

--- a/morph/react/restricted-names.js
+++ b/morph/react/restricted-names.js
@@ -31,4 +31,6 @@ export default [
   'Router',
   'Route',
   'Link',
+  'Spring',
+  'Timing',
 ]

--- a/morph/react/to-component.js
+++ b/morph/react/to-component.js
@@ -1,4 +1,3 @@
-import getAnimatedValue from './get-animated-value.js'
 import getBody from './get-body.js'
 import getContext from './get-context.js'
 import getDefaultProps from './get-default-props.js'
@@ -11,9 +10,8 @@ export default ({ getImport, getStyles, name, state }) => {
   // TODO Emojis should be wrapped in <span>, have role="img", and have an accessible description
   // with aria-label or aria-labelledby  jsx-a11y/accessible-emoji
   return `/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars */
-import React from 'react'
 ${getDependencies(state, getImport)}
-${getAnimatedValue(state, name)}
+
 ${getStyles(state, name)}
 ${getFlatList(state, name)}
 ${getFormatters(state, name)}

--- a/morph/utils.js
+++ b/morph/utils.js
@@ -294,41 +294,20 @@ export const makeOnClickTracker = (node, state) => {
   }, event, props })`
 }
 
-export const hasAnimatedChild = node =>
-  node.children && node.children.some(child => child.isAnimated)
-
-const getDefaultValue = (node, name) => {
-  const prop = node.properties.find(
-    prop => prop.name === name || `"--${prop.name}` === name.split(/[0-9]/)[0]
-  )
-  return prop ? prop.value : ''
-}
-
 // const isRotate = name =>
 //   name === 'rotate' || name === 'rotateX' || name === 'rotateY'
 
 const getStandardAnimatedString = (node, prop, isNative) => {
-  // const baseScopeValue = getDefaultValue(node, prop.name)
-  // let fromValue
-  // let toValue
+  let value = `animated${node.id}${
+    prop.animationIndexOnBlock > 0 ? prop.animationIndexOnBlock : ''
+  }.${prop.name}`
 
-  // // TODO see if native needs the unit in all cases but PX (eg for rotate it may
-  // // need deg)
-  // if (typeof prop.value === 'number') {
-  //   fromValue = isNative
-  //     ? baseScopeValue
-  //     : getPropValue({ name: prop.name, value: baseScopeValue }, false)
-  //   toValue = isNative ? prop.value : getPropValue(prop, false)
-  //   // fromValue = baseScopeValue
-  //   // toValue = prop.value
-  // } else {
-  //   fromValue = `'${baseScopeValue}'`
-  //   toValue = `'${prop.value}'`
+  // const unit = getUnit(prop)
+  // if (unit) {
+  //   value = `\`\${${value}}${unit}\``
   // }
 
-  return `${isNative ? prop.name : `"--${prop.name}"`}: animated${node.id}.${
-    prop.name
-  }`
+  return `${isNative ? prop.name : `"--${prop.name}"`}: ${value}`
 }
 
 const getTransformString = (node, transform, isNative) => {
@@ -410,12 +389,6 @@ export const getNonAnimatedDynamicStyles = node => {
     }, {})
 }
 
-export const hasSpringAnimation = node =>
-  node.animations.some(anim => anim.curve === 'spring')
-
-export const hasTimingAnimation = node =>
-  node.animations.some(anim => anim.curve !== 'spring')
-
 export const getAllAnimatedProps = (node, isNative) => {
   const props = flatten(
     node.scopes.map(scope => scope.properties.filter(prop => prop.animation))
@@ -491,11 +464,8 @@ const TRANSFORM_WHITELIST = {
   perspective: true,
 }
 
-// TODO re-enable
-export const canUseNativeDriver = animation =>
-  // STYLES_WHITELIST[animation.name] ||
-  // TRANSFORM_WHITELIST[animation.name] ||
-  false
+export const canUseNativeDriver = name =>
+  STYLES_WHITELIST[name] || TRANSFORM_WHITELIST[name] || false
 
 const fontsOrder = ['eot', 'woff2', 'woff', 'ttf', 'svg', 'otf']
 

--- a/morph/utils.js
+++ b/morph/utils.js
@@ -308,30 +308,27 @@ const getDefaultValue = (node, name) => {
 //   name === 'rotate' || name === 'rotateX' || name === 'rotateY'
 
 const getStandardAnimatedString = (node, prop, isNative) => {
-  const baseScopeValue = getDefaultValue(node, prop.name)
-  let fromValue
-  let toValue
+  // const baseScopeValue = getDefaultValue(node, prop.name)
+  // let fromValue
+  // let toValue
 
-  // TODO see if native needs the unit in all cases but PX (eg for rotate it may
-  // need deg)
-  if (typeof prop.value === 'number') {
-    fromValue = isNative
-      ? baseScopeValue
-      : getPropValue({ name: prop.name, value: baseScopeValue }, false)
-    toValue = isNative ? prop.value : getPropValue(prop, false)
-    // fromValue = baseScopeValue
-    // toValue = prop.value
-  } else {
-    fromValue = `'${baseScopeValue}'`
-    toValue = `'${prop.value}'`
-  }
+  // // TODO see if native needs the unit in all cases but PX (eg for rotate it may
+  // // need deg)
+  // if (typeof prop.value === 'number') {
+  //   fromValue = isNative
+  //     ? baseScopeValue
+  //     : getPropValue({ name: prop.name, value: baseScopeValue }, false)
+  //   toValue = isNative ? prop.value : getPropValue(prop, false)
+  //   // fromValue = baseScopeValue
+  //   // toValue = prop.value
+  // } else {
+  //   fromValue = `'${baseScopeValue}'`
+  //   toValue = `'${prop.value}'`
+  // }
 
-  return `${
-    isNative ? prop.name : `"--${prop.name}"`
-  }: getAnimatedValue(this.animatedValue${getScopeIndex(
-    node,
-    prop.scope
-  )}, ${fromValue}, ${toValue})`
+  return `${isNative ? prop.name : `"--${prop.name}"`}: animated${node.id}.${
+    prop.name
+  }`
 }
 
 const getTransformString = (node, transform, isNative) => {

--- a/parse/__snapshots__/index.test.js.snap
+++ b/parse/__snapshots__/index.test.js.snap
@@ -7,7 +7,7 @@ Object {
   "slots": Array [],
   "views": Array [
     Object {
-      "animations": Array [],
+      "animations": Object {},
       "children": Array [],
       "id": "Main",
       "is": "Main",
@@ -42,10 +42,10 @@ Object {
   "slots": Array [],
   "views": Array [
     Object {
-      "animations": Array [],
+      "animations": Object {},
       "children": Array [
         Object {
-          "animations": Array [],
+          "animations": Object {},
           "id": "Text",
           "isAnimated": false,
           "isBasic": true,
@@ -99,10 +99,10 @@ Object {
   "slots": Array [],
   "views": Array [
     Object {
-      "animations": Array [],
+      "animations": Object {},
       "children": Array [
         Object {
-          "animations": Array [],
+          "animations": Object {},
           "id": "Before",
           "is": "Before",
           "isAnimated": false,
@@ -124,10 +124,10 @@ Object {
           "type": "Block",
         },
         Object {
-          "animations": Array [],
+          "animations": Object {},
           "children": Array [
             Object {
-              "animations": Array [],
+              "animations": Object {},
               "id": "ImageInside",
               "is": "ImageInside",
               "isAnimated": false,
@@ -168,7 +168,7 @@ Object {
               "type": "Block",
             },
             Object {
-              "animations": Array [],
+              "animations": Object {},
               "children": Array [],
               "id": "VerticalInside",
               "is": "VerticalInside",
@@ -214,7 +214,7 @@ Object {
           "type": "Block",
         },
         Object {
-          "animations": Array [],
+          "animations": Object {},
           "id": "After",
           "is": "After",
           "isAnimated": false,
@@ -328,7 +328,7 @@ Object {
           "type": "Block",
         },
         Object {
-          "animations": Array [],
+          "animations": Object {},
           "children": Array [],
           "id": "Last",
           "is": "Last",
@@ -405,10 +405,10 @@ Object {
   "slots": Array [],
   "views": Array [
     Object {
-      "animations": Array [],
+      "animations": Object {},
       "children": Array [
         Object {
-          "animations": Array [],
+          "animations": Object {},
           "id": "A1",
           "is": "A1",
           "isAnimated": false,
@@ -450,7 +450,7 @@ Object {
           "type": "Block",
         },
         Object {
-          "animations": Array [],
+          "animations": Object {},
           "id": "A2",
           "is": "A2",
           "isAnimated": false,
@@ -580,10 +580,10 @@ Object {
   ],
   "views": Array [
     Object {
-      "animations": Array [],
+      "animations": Object {},
       "children": Array [
         Object {
-          "animations": Array [],
+          "animations": Object {},
           "id": "Title",
           "is": "Title",
           "isAnimated": false,
@@ -672,7 +672,7 @@ Object {
           "type": "Block",
         },
         Object {
-          "animations": Array [],
+          "animations": Object {},
           "id": "CaptureText",
           "isAnimated": false,
           "isBasic": true,
@@ -716,10 +716,10 @@ Object {
           "type": "Block",
         },
         Object {
-          "animations": Array [],
+          "animations": Object {},
           "children": Array [
             Object {
-              "animations": Array [],
+              "animations": Object {},
               "children": Array [],
               "childrenProxyMap": null,
               "id": "Stuff",
@@ -882,10 +882,10 @@ Object {
   "slots": Array [],
   "views": Array [
     Object {
-      "animations": Array [],
+      "animations": Object {},
       "children": Array [
         Object {
-          "animations": Array [],
+          "animations": Object {},
           "id": "Text",
           "isAnimated": false,
           "isBasic": true,
@@ -1018,10 +1018,10 @@ Object {
   ],
   "views": Array [
     Object {
-      "animations": Array [],
+      "animations": Object {},
       "children": Array [
         Object {
-          "animations": Array [],
+          "animations": Object {},
           "children": Array [],
           "id": "EmptyWhen",
           "is": "EmptyWhen",

--- a/parse/__snapshots__/index.test.js.snap
+++ b/parse/__snapshots__/index.test.js.snap
@@ -9,6 +9,7 @@ Object {
     Object {
       "animations": Array [],
       "children": Array [],
+      "id": "Main",
       "is": "Main",
       "isAnimated": false,
       "isBasic": true,
@@ -45,6 +46,7 @@ Object {
       "children": Array [
         Object {
           "animations": Array [],
+          "id": "Text",
           "isAnimated": false,
           "isBasic": true,
           "isGroup": false,
@@ -64,6 +66,7 @@ Object {
           "type": "Block",
         },
       ],
+      "id": "Main",
       "is": "Main",
       "isAnimated": false,
       "isBasic": true,
@@ -100,6 +103,7 @@ Object {
       "children": Array [
         Object {
           "animations": Array [],
+          "id": "Before",
           "is": "Before",
           "isAnimated": false,
           "isBasic": true,
@@ -124,6 +128,7 @@ Object {
           "children": Array [
             Object {
               "animations": Array [],
+              "id": "ImageInside",
               "is": "ImageInside",
               "isAnimated": false,
               "isBasic": true,
@@ -165,6 +170,7 @@ Object {
             Object {
               "animations": Array [],
               "children": Array [],
+              "id": "VerticalInside",
               "is": "VerticalInside",
               "isAnimated": false,
               "isBasic": true,
@@ -186,6 +192,7 @@ Object {
               "type": "Block",
             },
           ],
+          "id": "Nested",
           "is": "Nested",
           "isAnimated": false,
           "isBasic": true,
@@ -208,6 +215,7 @@ Object {
         },
         Object {
           "animations": Array [],
+          "id": "After",
           "is": "After",
           "isAnimated": false,
           "isBasic": true,
@@ -322,6 +330,7 @@ Object {
         Object {
           "animations": Array [],
           "children": Array [],
+          "id": "Last",
           "is": "Last",
           "isAnimated": false,
           "isBasic": true,
@@ -363,6 +372,7 @@ Object {
           "type": "Block",
         },
       ],
+      "id": "BlueButton",
       "is": "BlueButton",
       "isAnimated": false,
       "isBasic": true,
@@ -399,6 +409,7 @@ Object {
       "children": Array [
         Object {
           "animations": Array [],
+          "id": "A1",
           "is": "A1",
           "isAnimated": false,
           "isBasic": true,
@@ -440,6 +451,7 @@ Object {
         },
         Object {
           "animations": Array [],
+          "id": "A2",
           "is": "A2",
           "isAnimated": false,
           "isBasic": true,
@@ -480,6 +492,7 @@ Object {
           "type": "Block",
         },
       ],
+      "id": "A",
       "is": "A",
       "isAnimated": false,
       "isBasic": true,
@@ -571,6 +584,7 @@ Object {
       "children": Array [
         Object {
           "animations": Array [],
+          "id": "Title",
           "is": "Title",
           "isAnimated": false,
           "isBasic": true,
@@ -659,6 +673,7 @@ Object {
         },
         Object {
           "animations": Array [],
+          "id": "CaptureText",
           "isAnimated": false,
           "isBasic": true,
           "isGroup": false,
@@ -707,6 +722,7 @@ Object {
               "animations": Array [],
               "children": Array [],
               "childrenProxyMap": null,
+              "id": "Stuff",
               "isAnimated": false,
               "isBasic": false,
               "isGroup": true,
@@ -727,6 +743,7 @@ Object {
               "type": "Block",
             },
           ],
+          "id": "List",
           "isAnimated": false,
           "isBasic": true,
           "isGroup": true,
@@ -770,6 +787,7 @@ Object {
           "type": "Block",
         },
       ],
+      "id": "Vertical",
       "isAnimated": false,
       "isBasic": true,
       "isGroup": true,
@@ -868,6 +886,7 @@ Object {
       "children": Array [
         Object {
           "animations": Array [],
+          "id": "Text",
           "isAnimated": false,
           "isBasic": true,
           "isGroup": false,
@@ -960,6 +979,7 @@ Object {
           "type": "Block",
         },
       ],
+      "id": "Locals",
       "is": "Locals",
       "isAnimated": false,
       "isBasic": true,
@@ -1003,6 +1023,7 @@ Object {
         Object {
           "animations": Array [],
           "children": Array [],
+          "id": "EmptyWhen",
           "is": "EmptyWhen",
           "isAnimated": false,
           "isBasic": true,
@@ -1212,6 +1233,7 @@ Object {
           "type": "Block",
         },
       ],
+      "id": "Warning",
       "is": "Warning",
       "isAnimated": false,
       "isBasic": true,

--- a/parse/helpers.js
+++ b/parse/helpers.js
@@ -163,9 +163,15 @@ export const getAnimation = line => {
     }
   }
 
+  addDefaults(animationType, properties)
+
   return {
+    id: Object.keys(properties)
+      .sort()
+      .map(key => `${key}${properties[key]}`)
+      .join(''),
     defaultValue: getValue(defaultValue),
-    properties: addDefaults(animationType, properties),
+    properties,
   }
 }
 

--- a/parse/helpers.js
+++ b/parse/helpers.js
@@ -57,7 +57,7 @@ const dymPropMatcher = new DidYouMeanMatcher([
 export const didYouMeanBlock = block => dymBlockMatcher.get(block)
 export const didYouMeanProp = prop => dymPropMatcher.get(prop)
 
-const ANIMATION = /(.+)(?:\s)(spring|linear|easeOut|easeIn|easeInOut|ease)(?:\s?(.*)?)/
+const ANIMATION = /(.+)(?:\s)(spring|linear|easeOut|easeInOut|easeIn|ease)(?:\s?(.*)?)/
 const BASIC = /^(CaptureEmail|CaptureFile|CaptureNumber|CapturePhone|CaptureSecure|CaptureText|CaptureTextArea|Horizontal|Image|List|Svg|SvgCircle|SvgEllipse|SvgDefs|SvgGroup|SvgLinearGradient|SvgRadialGradient|SvgLine|SvgPath|SvgPolygon|SvgPolyline|SvgRect|SvgSymbol|SvgText|SvgUse|SvgStop|Text|Vertical)$/i
 const BLOCK = /^([A-Z][a-zA-Z0-9]*)(\s+([A-Z][a-zA-Z0-9]*))?$/
 const BOOL = /^(false|true)$/i

--- a/parse/index.js
+++ b/parse/index.js
@@ -45,6 +45,24 @@ export default ({
   const warnings = []
   let lastCapture
 
+  const blockIds = []
+  const getBlockId = node => {
+    let maybeId = node.is || node.name
+
+    if (!blockIds.includes(maybeId)) {
+      blockIds.push(maybeId)
+      return maybeId
+    }
+
+    let index = 1
+    while (blockIds.includes(`${maybeId}${index}`)) {
+      index++
+    }
+    const id = `${maybeId}${index}`
+    blockIds.push(id)
+    return id
+  }
+
   const getChildrenProxyMap = block => {
     const childrenProxyMap = {}
 
@@ -171,6 +189,7 @@ export default ({
         lastCapture = block
       }
     }
+    block.id = getBlockId(block)
 
     const last = stack[stack.length - 1]
     if (last) {
@@ -425,10 +444,19 @@ export default ({
             block.isAnimatedReallyAnimated ||
             propNode.animation.curve === 'spring'
 
+          let baseValue = null
+          const baseProp = properties.find(prop => prop.name === name)
+          if (baseProp) {
+            baseValue = baseProp.value
+          }
+
           block.animations.push({
             ...currentAnimation.properties,
+            id: currentAnimation.id,
             name,
             scope: scope.slotName,
+            value: currentAnimation.defaultValue,
+            baseValue,
           })
         }
 

--- a/parse/index.js
+++ b/parse/index.js
@@ -159,7 +159,7 @@ export default ({
     const block = {
       type: 'Block',
       name,
-      animations: [],
+      animations: {},
       isAnimated: false,
       isBasic: isBasic(name),
       isGroup: false,
@@ -440,23 +440,40 @@ export default ({
           propNode.value = currentAnimation.defaultValue
           propNode.animation = currentAnimation.properties
 
-          block.isAnimatedReallyAnimated =
-            block.isAnimatedReallyAnimated ||
-            propNode.animation.curve === 'spring'
-
-          let baseValue = null
-          const baseProp = properties.find(prop => prop.name === name)
-          if (baseProp) {
-            baseValue = baseProp.value
+          if (propNode.animation.curve === 'spring') {
+            block.hasSpringAnimation = true
+          } else {
+            block.hasTimingAnimation = true
           }
 
-          block.animations.push({
-            ...currentAnimation.properties,
-            id: currentAnimation.id,
-            name,
-            scope: scope.slotName,
+          const animationIndexOnBlock = Object.keys(block.animations).length
+          propNode.animationIndexOnBlock = animationIndexOnBlock
+
+          if (!block.animations[currentAnimation.id]) {
+            block.animations[currentAnimation.id] = {
+              index: animationIndexOnBlock,
+              animation: currentAnimation,
+              props: {},
+            }
+          }
+
+          if (!block.animations[currentAnimation.id].props[name]) {
+            let baseValue = null
+            const baseProp = properties.find(prop => prop.name === name)
+            if (baseProp) {
+              baseValue = baseProp.value
+            }
+
+            block.animations[currentAnimation.id].props[name] = {
+              name,
+              scopes: [],
+              value: baseValue,
+            }
+          }
+
+          block.animations[currentAnimation.id].props[name].scopes.push({
+            name: scope.slotName,
             value: currentAnimation.defaultValue,
-            baseValue,
           })
         }
 

--- a/parse/index.js
+++ b/parse/index.js
@@ -141,6 +141,7 @@ export default ({
     const block = {
       type: 'Block',
       name,
+      animations: [],
       isAnimated: false,
       isBasic: isBasic(name),
       isGroup: false,
@@ -286,7 +287,6 @@ export default ({
     const scopes = []
     let scope
     let inScope = false
-    block.animations = []
 
     for (let j = i; j <= endOfBlockIndex; j++) {
       const line = lines[j]
@@ -415,30 +415,21 @@ export default ({
         }
 
         if (tags.animation && scope) {
+          block.isAnimated = true
+
           const currentAnimation = getAnimation(value)
-          const existingScope =
-            block.animations.length > 0 &&
-            // eslint-disable-next-line
-            block.animations.some(animation => {
-              return (
-                animation.scope === scope.slotName &&
-                animation.curve === currentAnimation.properties.curve
-              )
-            }, currentAnimation)
           propNode.value = currentAnimation.defaultValue
           propNode.animation = currentAnimation.properties
-          block.isAnimated = true
-          if (!block.isAnimatedReallyAnimated) {
-            block.isAnimatedReallyAnimated =
-              propNode.animation.curve === 'spring'
-          }
-          if (!existingScope) {
-            block.animations.push({
-              ...currentAnimation.properties,
-              name,
-              scope: scope.slotName,
-            })
-          }
+
+          block.isAnimatedReallyAnimated =
+            block.isAnimatedReallyAnimated ||
+            propNode.animation.curve === 'spring'
+
+          block.animations.push({
+            ...currentAnimation.properties,
+            name,
+            scope: scope.slotName,
+          })
         }
 
         if (scope) {

--- a/parse/index.js
+++ b/parse/index.js
@@ -446,16 +446,15 @@ export default ({
             block.hasTimingAnimation = true
           }
 
-          const animationIndexOnBlock = Object.keys(block.animations).length
-          propNode.animationIndexOnBlock = animationIndexOnBlock
-
           if (!block.animations[currentAnimation.id]) {
             block.animations[currentAnimation.id] = {
-              index: animationIndexOnBlock,
+              index: Object.keys(block.animations).length,
               animation: currentAnimation,
               props: {},
             }
           }
+          propNode.animationIndexOnBlock =
+            block.animations[currentAnimation.id].animationIndexOnBlock
 
           if (!block.animations[currentAnimation.id].props[name]) {
             let baseValue = null


### PR DESCRIPTION
This PR fixes #112, #98 and #108. It also supports `Timing` animations in native and fixes `delay` on DOM since `react-spring` supports it already. It also fixes `easeInOut`.

To wrap up animations, I'd say we're missing the following:
- support spring on `hover` #107,
- add `onAnimationDone` callback #111,
- add `before` and `after` system scopes - this should allow for in/out transitions, and
- stagger cards in lists.

The last two can be done with a logic layer in JS so I wouldn't say there's a lot of rush on them.

Am I missing anything @amymc, @tombrewsviews?

NOTE: After releasing this version, we'd need to update `@viewstools/use` to add `@viewstools/animations` as a dependency.