### PR TITLE
Fix: don't morph empty props

### DIFF
--- a/parse/__snapshots__/index.test.js.snap
+++ b/parse/__snapshots__/index.test.js.snap
@@ -1135,59 +1135,27 @@ Object {
               "type": "Property",
               "value": "1px solid red",
             },
+            Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 8,
+                  "line": 7,
+                },
+                "start": Object {
+                  "column": 0,
+                  "line": 7,
+                },
+              },
+              "name": "color",
+              "tags": Object {
+                "style": true,
+                "validSlot": null,
+              },
+              "type": "Property",
+              "value": "red",
+            },
           ],
           "scopes": Array [
-            Object {
-              "isLocal": false,
-              "isSystem": false,
-              "name": "when",
-              "properties": Array [
-                Object {
-                  "loc": Object {
-                    "end": Object {
-                      "column": 3,
-                      "line": 6,
-                    },
-                    "start": Object {
-                      "column": 0,
-                      "line": 6,
-                    },
-                  },
-                  "name": "when",
-                  "scope": undefined,
-                  "tags": Object {
-                    "scope": "",
-                    "shouldBeSlot": true,
-                    "validSlot": null,
-                  },
-                  "type": "Property",
-                  "value": "",
-                },
-                Object {
-                  "loc": Object {
-                    "end": Object {
-                      "column": 8,
-                      "line": 7,
-                    },
-                    "start": Object {
-                      "column": 0,
-                      "line": 7,
-                    },
-                  },
-                  "name": "color",
-                  "scope": undefined,
-                  "tags": Object {
-                    "style": true,
-                    "validSlot": null,
-                  },
-                  "type": "Property",
-                  "value": "red",
-                },
-              ],
-              "slotIsNot": undefined,
-              "slotName": undefined,
-              "value": "props.when",
-            },
             Object {
               "isLocal": false,
               "isSystem": false,

--- a/parse/index.js
+++ b/parse/index.js
@@ -373,12 +373,14 @@ export default ({
                 'This when has no condition assigned to it. Add one like: "when <isCondition"',
               line,
             })
+            continue
           } else if (!tags.validSlot) {
             warnings.push({
               loc,
               type: `The slot name "${name}" isn't valid. Fix it like: "when <isCondition" `,
               line,
             })
+            continue
           }
 
           if (isSystem && slotIsNot) {
@@ -419,6 +421,7 @@ export default ({
               type: `The value you used in the slot "${name}" is invalid`,
               line,
             })
+            continue
           }
         }
 
@@ -435,6 +438,15 @@ export default ({
         }
         if (tags.style && tags.slot) {
           block.maybeAnimated = true
+        }
+
+        if (value === '' && name !== 'text') {
+          warnings.push({
+            loc,
+            type: `"${name}" has no value. Please give it a value.`,
+            line,
+          })
+          continue
         }
 
         propNode = {

--- a/parse/index.js
+++ b/parse/index.js
@@ -33,6 +33,7 @@ export default ({
   enableLocalScopes = true,
   enableSystemScopes = true,
   skipComments = true,
+  skipInvalidProps = true,
   source,
 } = {}) => {
   // convert crlf to lf
@@ -373,14 +374,14 @@ export default ({
                 'This when has no condition assigned to it. Add one like: "when <isCondition"',
               line,
             })
-            continue
+            if (skipInvalidProps) continue
           } else if (!tags.validSlot) {
             warnings.push({
               loc,
               type: `The slot name "${name}" isn't valid. Fix it like: "when <isCondition" `,
               line,
             })
-            continue
+            if (skipInvalidProps) continue
           }
 
           if (isSystem && slotIsNot) {
@@ -421,7 +422,7 @@ export default ({
               type: `The value you used in the slot "${name}" is invalid`,
               line,
             })
-            continue
+            if (skipInvalidProps) continue
           }
         }
 
@@ -446,7 +447,7 @@ export default ({
             type: `"${name}" has no value. Please give it a value.`,
             line,
           })
-          continue
+          if (skipInvalidProps) continue
         }
 
         propNode = {


### PR DESCRIPTION
https://github.com/viewstools/morph/issues/87

Not sure if this is exactly what we want...
If a user passes a `when` or an `onWhen` with no value they just get ignored, but the following properties are morphed as though they're not scoped. 

So for example, this view: 
```
Label Text
height 10
when
height 20
color
text
backgroundColor < red
```

becomes this:
```
const Label = css({
  label: 'Label',
  height: 20,
  backgroundColor: 'var(--backgroundColor)',
});

const Empty = props => {
  return (
    <span
      data-test-id={`${props['data-test-id'] || 'Label'}|`}
      style={{ '--backgroundColor': props.backgroundColor }}
      className={`views-block ${Label}`}
    />
  );
};

Empty.defaultProps = { backgroundColor: 'red' };
export default Empty;
```

So the second value for `height` overwrites the first. I suppose, ideally we would just disregard all props that follow a `when` with no condition, but that seems like more work for something that was invalid syntax in the first place 🙃 