### PR TITLE
feat: add autogenerated comment on each .view.js file

### DIFF
--- a/morph/react/to-component.js
+++ b/morph/react/to-component.js
@@ -8,7 +8,8 @@ import getLocals from './get-locals.js'
 export default ({ getImport, getStyles, name, state }) => {
   // TODO Emojis should be wrapped in <span>, have role="img", and have an accessible description
   // with aria-label or aria-labelledby  jsx-a11y/accessible-emoji
-  return `/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars, no-dupe-keys */
+  return `// This file is auto-generated, please don't edit it. More info: https://github.com/viewstools/docs/blob/master/UseViews/README.md#viewjs-is-auto-generated-and-shouldnt-be-edited
+/* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars, no-dupe-keys */
 ${getDependencies(state, getImport)}
 
 ${getStyles(state, name)}

--- a/morph/react/to-component.js
+++ b/morph/react/to-component.js
@@ -8,7 +8,7 @@ import getLocals from './get-locals.js'
 export default ({ getImport, getStyles, name, state }) => {
   // TODO Emojis should be wrapped in <span>, have role="img", and have an accessible description
   // with aria-label or aria-labelledby  jsx-a11y/accessible-emoji
-  return `// This file is auto-generated, Edit ${name}.view to change it. More info: https://github.com/viewstools/docs/blob/master/UseViews/README.md#viewjs-is-auto-generated-and-shouldnt-be-edited
+  return `// This file is auto-generated. Edit ${name}.view to change it. More info: https://github.com/viewstools/docs/blob/master/UseViews/README.md#viewjs-is-auto-generated-and-shouldnt-be-edited
 /* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars, no-dupe-keys */
 ${getDependencies(state, getImport)}
 

--- a/morph/react/to-component.js
+++ b/morph/react/to-component.js
@@ -8,7 +8,7 @@ import getLocals from './get-locals.js'
 export default ({ getImport, getStyles, name, state }) => {
   // TODO Emojis should be wrapped in <span>, have role="img", and have an accessible description
   // with aria-label or aria-labelledby  jsx-a11y/accessible-emoji
-  return `// This file is auto-generated, please don't edit it. More info: https://github.com/viewstools/docs/blob/master/UseViews/README.md#viewjs-is-auto-generated-and-shouldnt-be-edited
+  return `// This file is auto-generated, Edit ${name}.view to change it. More info: https://github.com/viewstools/docs/blob/master/UseViews/README.md#viewjs-is-auto-generated-and-shouldnt-be-edited
 /* eslint-disable jsx-a11y/accessible-emoji, no-unused-vars, no-dupe-keys */
 ${getDependencies(state, getImport)}
 


### PR DESCRIPTION
This PR adds a comment on the top of each `.view.js` file.

![code](https://user-images.githubusercontent.com/31494769/57971435-c4a67300-7953-11e9-9869-dbf155f8d97e.png)

Close #27 

cc @dariocravero 