### PR TITLE
feat: morph/react allow item transformation on list item provider

### DIFF
--- a/morph/react/get-dependencies.js
+++ b/morph/react/get-dependencies.js
@@ -154,6 +154,14 @@ export default (state, getImport, file) => {
     dependencies.push(getImport('ViewsUseIsMedia'))
   }
 
+  let isUsingDataTransform = existsSync(
+    path.join(path.dirname(file), 'useListItemDataTransform.js')
+  )
+  if (isUsingDataTransform) {
+    dependencies.push(
+      "import useListItemDataTransform from './useListItemDataTransform.js'"
+    )
+  }
   let isUsingDataOnChange = existsSync(
     path.join(path.dirname(file), 'useListItemDataOnChange.js')
   )

--- a/views/ViewsData.js
+++ b/views/ViewsData.js
@@ -533,36 +533,3 @@ function log(stuff) {
     }
   }, 500)
 }
-
-export function ListItemDataProvider(props) {
-  let value = useMemo(() => ({ [props.context]: props.item }), [
-    props.context,
-    props.item,
-  ])
-  let valueItem = useMemo(() => ({
-    [`${props.context}_item`]: {
-      index: props.index,
-      indexReverse: props.list.length - props.index,
-      isFirst: props.index === 0,
-      isLast: props.index === props.list.length - 1,
-    },
-  }))
-
-  return (
-    <DataProvider
-      context={props.context}
-      value={value}
-      onChange={props.onChange}
-      onSubmit={props.onSubmit}
-      viewPath={props.viewPath}
-    >
-      <DataProvider
-        context={`${props.context}_item`}
-        value={valueItem}
-        viewPath={props.viewPath}
-      >
-        {props.children}
-      </DataProvider>
-    </DataProvider>
-  )
-}


### PR DESCRIPTION
I came across this case when the new data provider aggregated data from `props.item` as well as from another data provider, so I thought it may be a good approach to add this extension point to be in line with the data pattern. As an addition to it I also moved the logic from `ViewData.ListItemDataProvider` into the `ListItem` as I think it's only there where those data providers will ever be used together (plus, it made it easier to check where to get that `value` from). Let me know please if you think it makes sense or if you have other ideas.