### PR TITLE
feat: morph/react provide change function for onSubmit action

### DIFF
--- a/views/ViewsData.js
+++ b/views/ViewsData.js
@@ -140,6 +140,20 @@ export function DataProvider(props) {
   }, [props.value]) // eslint-disable-line
   // ignore dispatch
 
+  function _onChange(value, changePath = props.context) {
+    if (typeof value === 'function') {
+      dispatch({ type: SET_FN, fn: value })
+    } else if (!changePath) {
+      dispatch({ type: RESET, value })
+    } else {
+      dispatch({
+        type: SET,
+        path: changePath,
+        value,
+      })
+    }
+  }
+
   // keep track of props.onChange outside of the following effect to
   // prevent loops. Making the function useCallback didn't work
   let onSubmit = useRef(props.onSubmit)
@@ -153,7 +167,11 @@ export function DataProvider(props) {
 
     try {
       dispatch({ type: IS_SUBMITTING, value: true })
-      let res = await onSubmit.current(stateRef.current, args)
+      let res = await onSubmit.current({
+        value: stateRef.current,
+        args,
+        onChange: _onChange,
+      })
       isSubmitting.current = false
 
       if (!res) {


### PR DESCRIPTION
* this will allow us to update the data after submit completed

I gave it a try and implemented this option to pass an `onChange` function as an argument of `onSubmit` so that we could update some data (e.g. clearing some data as we've seen yesterday). I tested that against the implementation of pay now functionality and seemed to behave as expected. Let me know if you see any issues with this approach please. Thanks