### PR TITLE
fix: morph/react prevent passing itemDataContextName as props

### DIFF
--- a/morph/react-dom/block-properties.js
+++ b/morph/react-dom/block-properties.js
@@ -20,7 +20,7 @@ export function enter(node, parent, state) {
   PropertyFormat.enter(node, parent, state)
   PropertyViewPath.enter(node, parent, state)
 
-  node.properties.forEach(propNode => {
+  node.properties.forEach((propNode) => {
     if (
       propNode.name === 'lazy' ||
       propNode.name === 'at' ||
@@ -28,7 +28,7 @@ export function enter(node, parent, state) {
       propNode.name === 'onWhen' ||
       propNode.tags.unsupportedShorthand ||
       (!isValidPropertyForBlock(propNode, node, state) && node.isBasic) ||
-      (propNode.name === 'from' &&
+      ((propNode.name === 'from' || propNode.name === 'itemDataContextName') &&
         (node.name === 'List' || node.name === 'Table')) ||
       (propNode.name === 'key' && parent.isList) ||
       (propNode.name === 'pass' && node.isList) ||

--- a/morph/react-native/block-properties.js
+++ b/morph/react-native/block-properties.js
@@ -15,7 +15,7 @@ export function enter(node, parent, state) {
   PropertyFormat.enter(node, parent, state)
   PropertyViewPath.enter(node, parent, state)
 
-  node.properties.forEach(propNode => {
+  node.properties.forEach((propNode) => {
     if (
       propNode.name === 'lazy' ||
       propNode.name === 'at' ||
@@ -23,7 +23,7 @@ export function enter(node, parent, state) {
       propNode.name === 'onWhen' ||
       propNode.tags.unsupportedShorthand ||
       (!isValidPropertyForBlock(propNode, node, state) && node.isBasic) ||
-      (propNode.name === 'from' &&
+      ((propNode.name === 'from' || propNode.name === 'itemDataContextName') &&
         (node.name === 'List' || node.name === 'Table')) ||
       (propNode.name === 'key' && parent.isList) ||
       (propNode.name === 'pass' && node.isList) ||


### PR DESCRIPTION
Neil correctly pointed out that we get an error in regard to `itemDataContextName` not being a recognized React props. It was happening due to it being passed to the React components - added this check so that it will be ignored.