### PR TITLE
feat: morph/react declare data at the block level

### DIFF
--- a/morph/react-dom.js
+++ b/morph/react-dom.js
@@ -31,9 +31,9 @@ export default ({
     animations: {},
     cssDynamic: false,
     cssStatic: false,
+    hasData: !!view.parsed.view.data,
     data: view.parsed.view.data,
-    dataFormat: view.parsed.view.dataFormat,
-    dataValidate: view.parsed.view.dataValidate,
+    dataBlocks: [],
     hasListItem: false,
     dependencies: new Set(),
     flow: null,
@@ -64,6 +64,7 @@ export default ({
     styles: {},
     stylesOrder: [],
     usedBlockNames: { [finalName]: 1, AutoSizer: 1, Column: 1, Table: 1 },
+    usedDataNames: [],
     uses: [],
     testIdKey: 'data-testid',
     testIdKeyAsProp: 'dataTestid',
@@ -104,10 +105,6 @@ export default ({
   //   }
   // }
 
-  if (state.data) {
-    state.use('ViewsUseData')
-  }
-
   if (name !== finalName) {
     console.warn(
       `// ${name} is a Views reserved name. To fix this, change its file name to something else.`
@@ -118,6 +115,10 @@ export default ({
   state.slots = view.parsed.slots
 
   walk(view.parsed.view, visitor, state)
+
+  if (state.hasData) {
+    state.use('ViewsUseData')
+  }
 
   return {
     code: toComponent({

--- a/morph/react-dom.js
+++ b/morph/react-dom.js
@@ -31,8 +31,6 @@ export default ({
     animations: {},
     cssDynamic: false,
     cssStatic: false,
-    hasData: !!view.parsed.view.data,
-    data: view.parsed.view.data,
     dataBlocks: [],
     hasListItem: false,
     dependencies: new Set(),
@@ -115,10 +113,6 @@ export default ({
   state.slots = view.parsed.slots
 
   walk(view.parsed.view, visitor, state)
-
-  if (state.hasData) {
-    state.use('ViewsUseData')
-  }
 
   return {
     code: toComponent({

--- a/morph/react-dom/block-go-to.js
+++ b/morph/react-dom/block-go-to.js
@@ -6,8 +6,8 @@ let DATA_VALUE = /props\.value/
 export let enter = (node, parent, state) => {
   if (node.goTo) {
     let { value } = getProp(node, 'goTo')
-    if (state.data && DATA_VALUE.test(value)) {
-      value = value.replace('props', 'data')
+    if ((state.data || node.data) && DATA_VALUE.test(value)) {
+      value = value.replace('props', node.data ? node.data.name : 'data')
     }
 
     state.render.push(

--- a/morph/react-dom/block-go-to.js
+++ b/morph/react-dom/block-go-to.js
@@ -6,8 +6,8 @@ let DATA_VALUE = /props\.value/
 export let enter = (node, parent, state) => {
   if (node.goTo) {
     let { value } = getProp(node, 'goTo')
-    if ((state.data || node.data) && DATA_VALUE.test(value)) {
-      value = value.replace('props', node.data ? node.data.name : 'data')
+    if (node.data && DATA_VALUE.test(value)) {
+      value = value.replace('props', node.data.name)
     }
 
     state.render.push(

--- a/morph/react-dom/block.js
+++ b/morph/react-dom/block.js
@@ -1,5 +1,6 @@
 import * as BlockAddTestIdProp from '../react/block-add-test-id-prop.js'
 import * as BlockAddViewPath from '../react/block-add-view-path.js'
+import * as BlockAddData from '../react/block-add-data'
 import * as BlockCapture from './block-capture.js'
 import * as BlockColumn from '../react/block-column.js'
 import * as BlockExplicitChildren from '../react/block-explicit-children.js'
@@ -23,6 +24,8 @@ export let enter = [
   BlockName.enter,
   BlockTable.enter,
   BlockColumn.enter,
+
+  BlockAddData.enter,
 
   BlockCapture.enter,
   BlockGoTo.enter,

--- a/morph/react-dom/get-value-for-property.js
+++ b/morph/react-dom/get-value-for-property.js
@@ -61,7 +61,7 @@ let ON_IS_SELECTED = /(onClick|onPress|goTo)/
 
 export default function getValueForProperty(node, parent, state) {
   if (
-    state.data &&
+    (state.data || parent.data) &&
     (node.value === '!props.value' ||
       node.value === 'props.value' ||
       node.value === 'props.onSubmit' ||
@@ -74,8 +74,9 @@ export default function getValueForProperty(node, parent, state) {
       node.value === 'props.isSubmitting' ||
       node.value === '!props.isSubmitting')
   ) {
+    let value = parent.data ? `${parent.data.name}.` : 'data.'
     return {
-      [node.name]: `{${node.value.replace('props.', 'data.')}}`,
+      [node.name]: `{${node.value.replace('props.', value)}}`,
     }
   } else if (/!?props\.(isFlow|flow)$/.test(node.value)) {
     let flowPath = getFlowPath(node, parent, state)

--- a/morph/react-dom/get-value-for-property.js
+++ b/morph/react-dom/get-value-for-property.js
@@ -61,7 +61,7 @@ let ON_IS_SELECTED = /(onClick|onPress|goTo)/
 
 export default function getValueForProperty(node, parent, state) {
   if (
-    (state.data || parent.data) &&
+    parent.data &&
     (node.value === '!props.value' ||
       node.value === 'props.value' ||
       node.value === 'props.onSubmit' ||
@@ -74,9 +74,8 @@ export default function getValueForProperty(node, parent, state) {
       node.value === 'props.isSubmitting' ||
       node.value === '!props.isSubmitting')
   ) {
-    let value = parent.data ? `${parent.data.name}.` : 'data.'
     return {
-      [node.name]: `{${node.value.replace('props.', value)}}`,
+      [node.name]: `{${node.value.replace('props.', `${parent.data.name}.`)}}`,
     }
   } else if (/!?props\.(isFlow|flow)$/.test(node.value)) {
     let flowPath = getFlowPath(node, parent, state)

--- a/morph/react-native.js
+++ b/morph/react-native.js
@@ -32,9 +32,8 @@ export default ({
     animations: {},
     animated: new Set(),
     images: [],
+    hasData: !!view.parsed.view.data,
     data: view.parsed.view.data,
-    dataFormat: view.parsed.view.dataFormat,
-    dataValidate: view.parsed.view.dataValidate,
     hasListItem: false,
     dependencies: new Set(),
     flow: null,
@@ -70,6 +69,7 @@ export default ({
     tools,
     reactNativeLibraryImport,
     usedBlockNames: { [finalName]: 1, AutoSizer: 1, Column: 1, Table: 1 },
+    usedDataNames: [],
     uses: [],
     use(block, isLazy = false) {
       if (isLazy) {
@@ -111,7 +111,7 @@ export default ({
   maybeUsesTextInput(state)
   maybeUsesStyleSheet(state)
 
-  if (state.data) {
+  if (state.hasData) {
     state.use('ViewsUseData')
   }
 

--- a/morph/react-native.js
+++ b/morph/react-native.js
@@ -32,8 +32,6 @@ export default ({
     animations: {},
     animated: new Set(),
     images: [],
-    hasData: !!view.parsed.view.data,
-    data: view.parsed.view.data,
     hasListItem: false,
     dependencies: new Set(),
     flow: null,
@@ -110,10 +108,6 @@ export default ({
 
   maybeUsesTextInput(state)
   maybeUsesStyleSheet(state)
-
-  if (state.hasData) {
-    state.use('ViewsUseData')
-  }
 
   return {
     code: toComponent({

--- a/morph/react-native/get-value-for-property.js
+++ b/morph/react-native/get-value-for-property.js
@@ -62,7 +62,7 @@ let ON_IS_SELECTED = /(onClick|onPress|goTo)/
 
 export default function getValueForProperty(node, parent, state) {
   if (
-    (state.data || parent.data) &&
+    parent.data &&
     (node.value === '!props.value' ||
       node.value === 'props.value' ||
       node.value === 'props.onSubmit' ||
@@ -75,9 +75,8 @@ export default function getValueForProperty(node, parent, state) {
       node.value === 'props.isSubmitting' ||
       node.value === '!props.isSubmitting')
   ) {
-    let value = parent.data ? `${parent.data.name}.` : 'data.'
     return {
-      [node.name]: `{${node.value.replace('props.', value)}}`,
+      [node.name]: `{${node.value.replace('props.', `${parent.data.name}.`)}}`,
     }
   } else if (/!?props\.(isFlow|flow)$/.test(node.value)) {
     let flowPath = getFlowPath(node, parent, state)

--- a/morph/react-native/get-value-for-property.js
+++ b/morph/react-native/get-value-for-property.js
@@ -62,7 +62,7 @@ let ON_IS_SELECTED = /(onClick|onPress|goTo)/
 
 export default function getValueForProperty(node, parent, state) {
   if (
-    state.data &&
+    (state.data || parent.data) &&
     (node.value === '!props.value' ||
       node.value === 'props.value' ||
       node.value === 'props.onSubmit' ||
@@ -75,8 +75,9 @@ export default function getValueForProperty(node, parent, state) {
       node.value === 'props.isSubmitting' ||
       node.value === '!props.isSubmitting')
   ) {
+    let value = parent.data ? `${parent.data.name}.` : 'data.'
     return {
-      [node.name]: `{${node.value.replace('props.', 'data.')}}`,
+      [node.name]: `{${node.value.replace('props.', value)}}`,
     }
   } else if (/!?props\.(isFlow|flow)$/.test(node.value)) {
     let flowPath = getFlowPath(node, parent, state)

--- a/morph/react/block-add-data.js
+++ b/morph/react/block-add-data.js
@@ -19,7 +19,7 @@ export function enter(node, parent, state) {
       state.usedDataNames.push(name)
     }
 
-    state.hasData = true
+    state.use('ViewsUseData')
   }
 }
 

--- a/morph/react/block-add-data.js
+++ b/morph/react/block-add-data.js
@@ -1,0 +1,68 @@
+import toCamelCase from 'to-camel-case'
+
+export function enter(node, parent, state) {
+  if (node.data) {
+    let name = getDataVariableName(node)
+
+    node.data.name = name
+
+    if (!state.usedDataNames.includes(name)) {
+      state.dataBlocks.push(
+        `let ${name} = fromData.useData({ viewPath, path: '${node.data.path}', `
+      )
+      maybeDataContext(node.data, state.dataBlocks)
+      maybeDataFormat(node.data.format, state.dataBlocks)
+      maybeDataValidate(node.data.validate, state.dataBlocks)
+      state.dataBlocks.push('})')
+
+      // pushing it on to the state to indicate if it was already defined
+      state.usedDataNames.push(name)
+    }
+
+    state.hasData = true
+  }
+}
+
+function getDataVariableName(node) {
+  // keep the same name if the data is defined at the view level
+  return node.isView
+    ? 'data'
+    : // using the format and validate as part of the name to uniquely identify a data key
+      `${toCamelCase(
+        [
+          node.data.path.replace(/\./g, '_'),
+          node.data.format?.formatIn,
+          node.data.format?.formatOut,
+          node.data.validate?.value,
+          node.data.validate?.required ? 'required' : null,
+          'data',
+        ]
+          .filter(Boolean)
+          .join('_')
+      )}`
+}
+
+function maybeDataContext(dataDefinition, data) {
+  if (dataDefinition.context === null) return
+
+  data.push(`context: '${dataDefinition.context}',`)
+}
+
+function maybeDataFormat(format, data) {
+  if (!format) return
+
+  if (format.formatIn) {
+    data.push(`formatIn: '${format.formatIn}',`)
+  }
+
+  if (format.formatOut) {
+    data.push(`formatOut: '${format.formatOut}',`)
+  }
+}
+function maybeDataValidate(validate, data) {
+  if (!validate || validate.type !== 'js') return
+  data.push(`validate: '${validate.value}',`)
+  if (validate.required) {
+    data.push('validateRequired: true,')
+  }
+}

--- a/morph/react/block-list.js
+++ b/morph/react/block-list.js
@@ -11,8 +11,8 @@ export function enter(node, parent, state) {
   if (!from) return
 
   let value = from.value
-  if (state.data && DATA_VALUE.test(value)) {
-    value = value.replace('props', 'data')
+  if ((state.data || node.data) && DATA_VALUE.test(value)) {
+    value = value.replace('props', node.data ? node.data.name : 'data')
   }
 
   state.render.push(
@@ -50,10 +50,14 @@ export function leave(node, parent, state) {
 }
 
 function defaultItemDataContextName(state, node, fromValue) {
-  let value =
-    state.data && DATA_VALUE.test(fromValue)
-      ? state.data.path.replace('.', '_')
-      : fromValue.replace('props.', '')
+  let value
+  if ((state.data || node.data) && DATA_VALUE.test(fromValue)) {
+    value = node.data
+      ? node.data.path.replace('.', '_')
+      : state.data.path.replace('.', '_')
+  } else {
+    value = fromValue.replace('props.', '')
+  }
   let singularValue = singular(value)
   if (singularValue !== value) {
     value = singularValue

--- a/morph/react/block-list.js
+++ b/morph/react/block-list.js
@@ -11,8 +11,8 @@ export function enter(node, parent, state) {
   if (!from) return
 
   let value = from.value
-  if ((state.data || node.data) && DATA_VALUE.test(value)) {
-    value = value.replace('props', node.data ? node.data.name : 'data')
+  if (node.data && DATA_VALUE.test(value)) {
+    value = value.replace('props', node.data.name)
   }
 
   state.render.push(
@@ -22,7 +22,7 @@ export function enter(node, parent, state) {
   if (state.viewPath) {
     let itemDataContextName =
       getProp(node, 'itemDataContextName') ||
-      defaultItemDataContextName(state, node, from.value)
+      defaultItemDataContextName(node, from.value)
     state.render.push(
       `<ListItem
         key={item.id || index}
@@ -49,15 +49,12 @@ export function leave(node, parent, state) {
   state.render.push(')}')
 }
 
-function defaultItemDataContextName(state, node, fromValue) {
-  let value
-  if ((state.data || node.data) && DATA_VALUE.test(fromValue)) {
-    value = node.data
+function defaultItemDataContextName(node, fromValue) {
+  let value =
+    node.data && DATA_VALUE.test(fromValue)
       ? node.data.path.replace('.', '_')
-      : state.data.path.replace('.', '_')
-  } else {
-    value = fromValue.replace('props.', '')
-  }
+      : fromValue.replace('props.', '')
+
   let singularValue = singular(value)
   if (singularValue !== value) {
     value = singularValue

--- a/morph/react/block-off-when.js
+++ b/morph/react/block-off-when.js
@@ -24,8 +24,8 @@ export function enter(node, parent, state) {
     if (parent && !isList(parent)) state.render.push('{')
 
     let value = onWhen.value
-    if ((state.data || node.data) && DATA_VALUES.test(value)) {
-      value = value.replace('props', node.data ? node.data.name : 'data')
+    if (node.data && DATA_VALUES.test(value)) {
+      value = value.replace('props', node.data.name)
     } else if (IS_MEDIA.test(value)) {
       let [, variable, media] = value.match(IS_MEDIA)
       value = `${variable.replace('props.', '')}.${media.toLowerCase()}`

--- a/morph/react/block-off-when.js
+++ b/morph/react/block-off-when.js
@@ -24,8 +24,8 @@ export function enter(node, parent, state) {
     if (parent && !isList(parent)) state.render.push('{')
 
     let value = onWhen.value
-    if (state.data && DATA_VALUES.test(value)) {
-      value = value.replace('props', 'data')
+    if ((state.data || node.data) && DATA_VALUES.test(value)) {
+      value = value.replace('props', node.data ? node.data.name : 'data')
     } else if (IS_MEDIA.test(value)) {
       let [, variable, media] = value.match(IS_MEDIA)
       value = `${variable.replace('props.', '')}.${media.toLowerCase()}`

--- a/morph/react/get-body.js
+++ b/morph/react/get-body.js
@@ -19,17 +19,6 @@ export default function getBody({ state, name, view }) {
     flow.push(`let setFlowTo = fromFlow.useSetFlowTo(viewPath)`)
   }
 
-  let data = []
-  if (state.data) {
-    data.push(
-      `let data = fromData.useData({ viewPath, path: '${state.data.path}', `
-    )
-    maybeDataContext(state.data, data)
-    maybeDataFormat(state.dataFormat, data)
-    maybeDataValidate(state.dataValidate, data)
-    data.push('})')
-  }
-
   let animated = getAnimated({ state })
   let expandedProps = getExpandedProps({ state })
   let listItemDataProvider = getListItemDataProvider({ state, name, view })
@@ -49,7 +38,7 @@ export default function getBody({ state, name, view }) {
     ${state.useIsHovered ? getUseIsHovered({ state }) : ''}
     ${state.useIsMedia ? 'let isMedia = useIsMedia()' : ''}
     ${flow.join('\n')}
-    ${data.join('\n')}
+    ${state.dataBlocks.join('\n')}
     ${animated.join('\n')}
 
   return ${ret}
@@ -57,30 +46,6 @@ export default function getBody({ state, name, view }) {
 
 ${listItemDataProvider}
 `
-  }
-}
-
-function maybeDataContext(dataDefinition, data) {
-  if (dataDefinition.context === null) return
-
-  data.push(`context: '${dataDefinition.context}',`)
-}
-function maybeDataFormat(format, data) {
-  if (!format) return
-
-  if (format.formatIn) {
-    data.push(`formatIn: '${format.formatIn}',`)
-  }
-
-  if (format.formatOut) {
-    data.push(`formatOut: '${format.formatOut}',`)
-  }
-}
-function maybeDataValidate(validate, data) {
-  if (!validate || validate.type !== 'js') return
-  data.push(`validate: '${validate.value}',`)
-  if (validate.required) {
-    data.push('validateRequired: true,')
   }
 }
 

--- a/morph/react/property-text.js
+++ b/morph/react/property-text.js
@@ -5,8 +5,10 @@ let HAS_RESTRICTED_CHARACTERS = /[{}<>/]/
 
 export function enter(node, parent, state) {
   if (node.name === 'text' && parent.name === 'Text') {
-    if (state.data && node.value === 'props.value') {
-      parent.explicitChildren = '{data.value}'
+    if ((state.data || parent.data) && node.value === 'props.value') {
+      parent.explicitChildren = parent.data
+        ? `{${parent.data.name}.value}`
+        : '{data.value}'
     } else if (hasCustomScopes(node, parent)) {
       parent.explicitChildren = wrap(getScopedCondition(node, parent, state))
     } else if (isSlot(node)) {

--- a/morph/react/property-text.js
+++ b/morph/react/property-text.js
@@ -5,10 +5,8 @@ let HAS_RESTRICTED_CHARACTERS = /[{}<>/]/
 
 export function enter(node, parent, state) {
   if (node.name === 'text' && parent.name === 'Text') {
-    if ((state.data || parent.data) && node.value === 'props.value') {
-      parent.explicitChildren = parent.data
-        ? `{${parent.data.name}.value}`
-        : '{data.value}'
+    if (parent.data && node.value === 'props.value') {
+      parent.explicitChildren = `{${parent.data.name}.value}`
     } else if (hasCustomScopes(node, parent)) {
       parent.explicitChildren = wrap(getScopedCondition(node, parent, state))
     } else if (isSlot(node)) {

--- a/morph/utils.js
+++ b/morph/utils.js
@@ -124,8 +124,8 @@ export function isFlow(prop) {
   return IS_FLOW.test(prop)
 }
 export function getScopedName({ name, blockNode, scope, state }) {
-  if (state.data && DATA_VALUES.test(name)) {
-    return name.replace('props', 'data')
+  if ((state.data || blockNode.data) && DATA_VALUES.test(name)) {
+    return name.replace('props', blockNode.data ? blockNode.data.name : 'data')
   } else if (
     blockNode &&
     hasCustomBlockParent(blockNode) &&

--- a/morph/utils.js
+++ b/morph/utils.js
@@ -124,8 +124,8 @@ export function isFlow(prop) {
   return IS_FLOW.test(prop)
 }
 export function getScopedName({ name, blockNode, scope, state }) {
-  if ((state.data || blockNode.data) && DATA_VALUES.test(name)) {
-    return name.replace('props', blockNode.data ? blockNode.data.name : 'data')
+  if (blockNode.data && DATA_VALUES.test(name)) {
+    return name.replace('props', blockNode.data.name)
   } else if (
     blockNode &&
     hasCustomBlockParent(blockNode) &&

--- a/parse/helpers.js
+++ b/parse/helpers.js
@@ -270,22 +270,6 @@ export let getDataValidate = (maybeProp) => {
   }
 }
 
-export let getFormat = (line) => {
-  let properties = {}
-  let values = line.split(' ')
-  let formatKey = values[0]
-
-  if (values.length === 2) {
-    properties[formatKey] = values[1]
-  } else {
-    properties[formatKey] = {}
-    for (let i = 1; i < values.length; i = i + 2) {
-      properties[formatKey][values[i]] = getValue(values[i + 1])
-    }
-  }
-
-  return properties
-}
 export let getProp = (line) => {
   // eslint-disable-next-line
   let [_, name, _1, value = ''] = get(PROP, line)

--- a/parse/index.js
+++ b/parse/index.js
@@ -355,18 +355,6 @@ export default ({
     lookForFonts(block)
     lookForMultiples(block)
 
-    let data = getData(block.properties.find((p) => p.name === 'data'))
-    if (data) {
-      let format = getDataFormat(
-        block.properties.find((p) => p.name === 'format')
-      )
-      let validate = getDataValidate(
-        block.properties.find((p) => p.name === 'validate')
-      )
-
-      block.data = { ...data, format, validate }
-    }
-
     let flowProp = block.properties.find((p) => p.name === 'is')
     if (flowProp) {
       block.isView = true
@@ -379,6 +367,18 @@ export default ({
         type: 'string',
         defaultValue: block.viewPath,
       })
+    } else {
+      let data = getData(block.properties.find((p) => p.name === 'data'))
+      if (data) {
+        let format = getDataFormat(
+          block.properties.find((p) => p.name === 'format')
+        )
+        let validate = getDataValidate(
+          block.properties.find((p) => p.name === 'validate')
+        )
+
+        block.data = { ...data, format, validate }
+      }
     }
   }
 

--- a/parse/index.js
+++ b/parse/index.js
@@ -8,7 +8,6 @@ import {
   getData,
   getDataFormat,
   getDataValidate,
-  getFormat,
   getProp,
   getPropType,
   getUnsupportedShorthandExpanded,
@@ -208,6 +207,7 @@ export default ({
       type: 'Block',
       name,
       animations: {},
+      isView: false,
       isAnimated: false,
       isBasic: isBasic(name),
       isCapture: isCapture(name),
@@ -354,6 +354,32 @@ export default ({
     parseProps(i, block, last)
     lookForFonts(block)
     lookForMultiples(block)
+
+    let data = getData(block.properties.find((p) => p.name === 'data'))
+    if (data) {
+      let format = getDataFormat(
+        block.properties.find((p) => p.name === 'format')
+      )
+      let validate = getDataValidate(
+        block.properties.find((p) => p.name === 'validate')
+      )
+
+      block.data = { ...data, format, validate }
+    }
+
+    let flowProp = block.properties.find((p) => p.name === 'is')
+    if (flowProp) {
+      block.isView = true
+      block.flow = flowProp.value
+      block.viewPath = path.dirname(file.replace(src.replace(/\\/g, '/'), ''))
+      block.viewPathParent = path.dirname(block.viewPath)
+
+      slots.push({
+        name: 'viewPath',
+        type: 'string',
+        defaultValue: block.viewPath,
+      })
+    }
   }
 
   function parseProps(i, block) {
@@ -522,10 +548,6 @@ export default ({
 
         if (name === 'onWhen' && /!?isMedia.+/.test(slotName)) {
           useIsMedia = true
-        }
-
-        if (name === 'format') {
-          block.format = getFormat(value)
         }
 
         if (value === '' && name !== 'text') {
@@ -742,6 +764,7 @@ export default ({
       type: 'Block',
       name: id,
       animations: {},
+      isView: false,
       isAnimated: false,
       isBasic: true,
       isCapture: false,
@@ -759,29 +782,6 @@ export default ({
       type: `The file for ${id} is empty and won't render! Add some blocks to it like:\n${topBlockShouldBe}\n  Text\n    text content`,
       line: '',
     })
-  }
-
-  let flowProp = view.properties.find((p) => p.name === 'is')
-  if (flowProp) {
-    view.isView = true
-    view.flow = flowProp.value
-    view.viewPath = path.dirname(file.replace(src.replace(/\\/g, '/'), ''))
-    view.viewPathParent = path.dirname(view.viewPath)
-
-    view.data = getData(view.properties.find((p) => p.name === 'data'))
-    view.dataFormat = getDataFormat(
-      view.properties.find((p) => p.name === 'dataFormat')
-    )
-    view.dataValidate = getDataValidate(
-      view.properties.find((p) => p.name === 'dataValidate')
-    )
-    slots.push({
-      name: 'viewPath',
-      type: 'string',
-      defaultValue: view.viewPath,
-    })
-  } else {
-    view.isView = false
   }
 
   view.isDefiningChildrenExplicitly = isDefiningChildrenExplicitly


### PR DESCRIPTION
This is the first iteration in declaring data at the block level in addition to the existing view level one. I had a chat with Tom about it and he said he would prefer to still have the option to declare data at the view level (as we do now) so that it can be reused in multiple places if needed. I think it should be advised to define the data as close to where it is used as possible, so I wouldn't see it being used very frequent anymore. If we see the view level data is not necessary we could completely remove that option in a next release I think, but for now I think it could be useful.
If `data` was defined both at the view level and at the block level the closest one (block level will take priority), for example:

```
Person View
data person.first_name
  Text
  data person.last_name
  text <value # the value will be the last_name in this case
```

The added benefit of this approach is that this will also be backward compatible. We discussed also the possibility of supporting more generic contexts for the data, but I think this will get out of scope for now as I don't see a real need for that (we could always just duplicate the data) and will get a bit harder to reason about it even (it's hard to tell what data will be assigned to a value). An example would look something like this where the `data` is defined at the `Horizontal` block and will be accessible from all children:

```
Person View
is together
  Horizontal
  data person.name
    Text
    text <value
    Text
    text <value
```

Another point I considered here is to reuse the `useData` variable if data path is used in multiple blocks, as this definition happens in `view.js` file. To accomplish it I considered including the `format` and `validate` function names in the data variable name so that it is redeclared only if those differ. This may change as I move to the next iteration to support multiple data keys per block.

Let me know what are your suggestions on that. Thanks!