### PR TITLE
fix: morph/react change onSubmit arguments to be an object

### DIFF
--- a/morph/react-dom/block.js
+++ b/morph/react-dom/block.js
@@ -19,13 +19,12 @@ import * as BlockTable from '../react/block-table.js'
 export let enter = [
   BlockMaybeSkip.enter,
   BlockSetTestId.enter,
+  BlockAddData.enter,
   BlockOffWhen.enter,
 
   BlockName.enter,
   BlockTable.enter,
   BlockColumn.enter,
-
-  BlockAddData.enter,
 
   BlockCapture.enter,
   BlockGoTo.enter,

--- a/views/ViewsData.tools.js
+++ b/views/ViewsData.tools.js
@@ -116,6 +116,20 @@ export function DataProvider(props) {
   }, [props.value]) // eslint-disable-line
   // ignore dispatch
 
+  function _onChange(value, changePath = props.context) {
+    if (typeof value === 'function') {
+      dispatch({ type: SET_FN, fn: value })
+    } else if (!changePath) {
+      dispatch({ type: RESET, value })
+    } else {
+      dispatch({
+        type: SET,
+        path: changePath,
+        value,
+      })
+    }
+  }
+
   // keep track of props.onChange outside of the following effect to
   // prevent loops. Making the function useCallback didn't work
   let onSubmit = useRef(props.onSubmit)
@@ -129,7 +143,11 @@ export function DataProvider(props) {
 
     try {
       dispatch({ type: IS_SUBMITTING, value: true })
-      let res = await onSubmit.current(stateRef.current, args)
+      let res = await onSubmit.current({
+        value: stateRef.current,
+        args,
+        onChange: _onChange,
+      })
       isSubmitting.current = false
 
       if (!res) {


### PR DESCRIPTION
* this change was probably removed due to a bad merge conflicts

Added also a fix for an issue I encountered with `onWhen`s as the data block logic should be executed before it.