### PR TITLE
fix: morph/react check if a prop value references data

### DIFF
--- a/morph/utils.js
+++ b/morph/utils.js
@@ -218,7 +218,9 @@ export let isSlot = (maybeNode1, maybeNode2) => {
   let node = maybeNode2 || maybeNode1
 
   return typeof node === 'string'
-    ? /(flow\.|data|isHovered|childProps|props|isBefore|isMedia\.)/.test(node)
+    ? /(flow\.|isHovered|childProps|props|isBefore|isMedia\.|Data\.)/.test(
+        node
+      )
     : isTag(node, 'slot')
 }
 export let isStyle = (node) => isTag(node, 'style')


### PR DESCRIPTION
There was this check I missed which ended up interpreting the data value as text rather than a variable. Not sure if this is the best approach to check if it contains `Data.`, let me know if you think we can handle it in a better way. thanks