### PR TITLE
feat: morph/react support multiple data keys per block

### DIFF
--- a/morph/react-dom/block-go-to.js
+++ b/morph/react-dom/block-go-to.js
@@ -1,13 +1,14 @@
-import { getProp } from '../utils.js'
+import { getDataForLoc, getProp } from '../utils.js'
 import safe from '../react/safe.js'
 
 let DATA_VALUE = /props\.value/
 
 export let enter = (node, parent, state) => {
   if (node.goTo) {
-    let { value } = getProp(node, 'goTo')
-    if (node.data && DATA_VALUE.test(value)) {
-      value = value.replace('props', node.data.name)
+    let { value, loc } = getProp(node, 'goTo')
+    let data = getDataForLoc(node, loc)
+    if (data && DATA_VALUE.test(value)) {
+      value = value.replace('props', data.name)
     }
 
     state.render.push(

--- a/morph/react-dom/get-value-for-property.js
+++ b/morph/react-dom/get-value-for-property.js
@@ -1,5 +1,6 @@
 import {
   getActionableParent,
+  getDataForLoc,
   getFlowPath,
   getProp,
   getScopedCondition,
@@ -60,8 +61,9 @@ let CHILD_VALUES = /props\.(isSelected|isHovered|isFocused|isSelectedHovered)/
 let ON_IS_SELECTED = /(onClick|onPress|goTo)/
 
 export default function getValueForProperty(node, parent, state) {
+  let data = getDataForLoc(parent, node.loc)
   if (
-    parent.data &&
+    data &&
     (node.value === '!props.value' ||
       node.value === 'props.value' ||
       node.value === 'props.onSubmit' ||
@@ -75,7 +77,7 @@ export default function getValueForProperty(node, parent, state) {
       node.value === '!props.isSubmitting')
   ) {
     return {
-      [node.name]: `{${node.value.replace('props.', `${parent.data.name}.`)}}`,
+      [node.name]: `{${node.value.replace('props.', `${data.name}.`)}}`,
     }
   } else if (/!?props\.(isFlow|flow)$/.test(node.value)) {
     let flowPath = getFlowPath(node, parent, state)

--- a/morph/react-native/get-value-for-property.js
+++ b/morph/react-native/get-value-for-property.js
@@ -5,6 +5,7 @@ import {
   getScopedCondition,
   getScopedImageCondition,
   getScopes,
+  getDataForLoc,
   hasCustomBlockParent,
   isValidImgSrc,
   pushImageToState,
@@ -61,8 +62,9 @@ let CHILD_VALUES = /props\.(isSelected|isHovered|isFocused|isSelectedHovered)/
 let ON_IS_SELECTED = /(onClick|onPress|goTo)/
 
 export default function getValueForProperty(node, parent, state) {
+  let data = getDataForLoc(parent, node.loc)
   if (
-    parent.data &&
+    data &&
     (node.value === '!props.value' ||
       node.value === 'props.value' ||
       node.value === 'props.onSubmit' ||
@@ -76,7 +78,7 @@ export default function getValueForProperty(node, parent, state) {
       node.value === '!props.isSubmitting')
   ) {
     return {
-      [node.name]: `{${node.value.replace('props.', `${parent.data.name}.`)}}`,
+      [node.name]: `{${node.value.replace('props.', `${data.name}.`)}}`,
     }
   } else if (/!?props\.(isFlow|flow)$/.test(node.value)) {
     let flowPath = getFlowPath(node, parent, state)

--- a/morph/react/block-add-data.js
+++ b/morph/react/block-add-data.js
@@ -1,18 +1,19 @@
+import toSnakeCase from 'to-snake-case'
 import toCamelCase from 'to-camel-case'
 
 export function enter(node, parent, state) {
-  if (node.data) {
-    let name = getDataVariableName(node)
+  for (let data of node.data) {
+    let name = getDataVariableName(data)
 
-    node.data.name = name
+    data.name = name
 
     if (!state.usedDataNames.includes(name)) {
       state.dataBlocks.push(
-        `let ${name} = fromData.useData({ viewPath, path: '${node.data.path}', `
+        `let ${name} = fromData.useData({ viewPath, path: '${data.path}', `
       )
-      maybeDataContext(node.data, state.dataBlocks)
-      maybeDataFormat(node.data.format, state.dataBlocks)
-      maybeDataValidate(node.data.validate, state.dataBlocks)
+      maybeDataContext(data, state.dataBlocks)
+      maybeDataFormat(data.format, state.dataBlocks)
+      maybeDataValidate(data.validate, state.dataBlocks)
       state.dataBlocks.push('})')
 
       // pushing it on to the state to indicate if it was already defined
@@ -23,23 +24,20 @@ export function enter(node, parent, state) {
   }
 }
 
-function getDataVariableName(node) {
-  // keep the same name if the data is defined at the view level
-  return node.isView
-    ? 'data'
-    : // using the format and validate as part of the name to uniquely identify a data key
-      `${toCamelCase(
-        [
-          node.data.path.replace(/\./g, '_'),
-          node.data.format?.formatIn,
-          node.data.format?.formatOut,
-          node.data.validate?.value,
-          node.data.validate?.required ? 'required' : null,
-          'data',
-        ]
-          .filter(Boolean)
-          .join('_')
-      )}`
+function getDataVariableName(data) {
+  return `${toCamelCase(
+    [
+      data.path.replace(/\./g, '_'),
+      data.format?.formatIn,
+      data.format?.formatOut,
+      data.validate?.value,
+      data.validate?.required ? 'required' : null,
+      'data',
+    ]
+      .filter(Boolean)
+      .map(toSnakeCase)
+      .join('_')
+  )}`
 }
 
 function maybeDataContext(dataDefinition, data) {

--- a/morph/react/block-off-when.js
+++ b/morph/react/block-off-when.js
@@ -1,6 +1,7 @@
 import {
   getFlowPath,
   getProp,
+  getDataForLoc,
   hasCustomBlockParent,
   isList,
   isView,
@@ -24,8 +25,9 @@ export function enter(node, parent, state) {
     if (parent && !isList(parent)) state.render.push('{')
 
     let value = onWhen.value
-    if (node.data && DATA_VALUES.test(value)) {
-      value = value.replace('props', node.data.name)
+    let data = getDataForLoc(node, onWhen.loc)
+    if (data && DATA_VALUES.test(value)) {
+      value = value.replace('props', data.name)
     } else if (IS_MEDIA.test(value)) {
       let [, variable, media] = value.match(IS_MEDIA)
       value = `${variable.replace('props.', '')}.${media.toLowerCase()}`

--- a/morph/react/get-body.js
+++ b/morph/react/get-body.js
@@ -102,6 +102,7 @@ function getAnimated({ state }) {
           let condition = getScopedName({
             name: scope.name,
             blockNode: item.block,
+            propNode: prop,
             scope,
             state,
           })
@@ -176,7 +177,7 @@ function getListItemDataProvider({ state, view }) {
         isFirst: props.index === 0,
         isLast: props.index === props.list.length - 1,
       },
-    }))
+    }), [props.context, props.index, props.list])
     ${
       isUsingDataOnChange ? 'let onChange = useListItemDataOnChange(props)' : ''
     }

--- a/morph/react/property-text.js
+++ b/morph/react/property-text.js
@@ -1,12 +1,18 @@
-import { getScopedCondition, hasCustomScopes, isSlot } from '../utils.js'
+import {
+  getScopedCondition,
+  getDataForLoc,
+  hasCustomScopes,
+  isSlot,
+} from '../utils.js'
 import wrap from './wrap.js'
 
 let HAS_RESTRICTED_CHARACTERS = /[{}<>/]/
 
 export function enter(node, parent, state) {
   if (node.name === 'text' && parent.name === 'Text') {
-    if (parent.data && node.value === 'props.value') {
-      parent.explicitChildren = `{${parent.data.name}.value}`
+    let data = getDataForLoc(parent, node.loc)
+    if (data && node.value === 'props.value') {
+      parent.explicitChildren = `{${data.name}.value}`
     } else if (hasCustomScopes(node, parent)) {
       parent.explicitChildren = wrap(getScopedCondition(node, parent, state))
     } else if (isSlot(node)) {

--- a/morph/utils.js
+++ b/morph/utils.js
@@ -123,9 +123,10 @@ let IS_FLOW = /!?props\.(isFlow|flow)$/
 export function isFlow(prop) {
   return IS_FLOW.test(prop)
 }
-export function getScopedName({ name, blockNode, scope, state }) {
-  if (blockNode.data && DATA_VALUES.test(name)) {
-    return name.replace('props', blockNode.data.name)
+export function getScopedName({ name, blockNode, propNode, scope, state }) {
+  let data = getDataForLoc(blockNode, propNode.loc)
+  if (data && DATA_VALUES.test(name)) {
+    return name.replace('props', data.name)
   } else if (
     blockNode &&
     hasCustomBlockParent(blockNode) &&
@@ -158,6 +159,7 @@ export function getScopedCondition(propNode, blockNode, state) {
     let when = getScopedName({
       name: scope.when,
       blockNode,
+      propNode,
       scope: scope.scope,
       state,
     })
@@ -585,4 +587,18 @@ export function getFlowPath(node, parent, state) {
   return setFlowTo.startsWith('/')
     ? JSON.stringify(setFlowTo)
     : `fromFlow.normalizePath(props.viewPath, '${setFlowTo}')`
+}
+
+/**
+ *
+ * Returns the closest data key which will apply for a given location in the block
+ *
+ */
+export function getDataForLoc(blockNode, loc) {
+  return (
+    blockNode.data
+      // the data should be defined before the current line
+      .filter((data) => data.loc.start.line < loc.start.line)
+      .sort((a, b) => b.loc.start.line - a.loc.start.line)?.[0]
+  )
 }

--- a/parse/index.js
+++ b/parse/index.js
@@ -355,6 +355,38 @@ export default ({
     lookForFonts(block)
     lookForMultiples(block)
 
+    let data = []
+    let index = 0
+    while (index < block.properties.length) {
+      let p = block.properties[index]
+      if (p.name === 'data') {
+        let currentData = getData(p)
+        currentData.loc = p.loc
+        data.push(currentData)
+
+        do {
+          index++
+          if (index === block.properties.length) {
+            break
+          }
+
+          p = block.properties[index]
+          if (p.name === 'format') {
+            currentData.format = getDataFormat(p)
+          } else if (p.name === 'validate') {
+            currentData.validate = getDataValidate(p)
+          }
+        } while (
+          index < block.properties.length &&
+          ['format', 'validate'].includes(p.name)
+        )
+      } else {
+        index++
+      }
+    }
+
+    block.data = data
+
     let flowProp = block.properties.find((p) => p.name === 'is')
     if (flowProp) {
       block.isView = true
@@ -367,18 +399,6 @@ export default ({
         type: 'string',
         defaultValue: block.viewPath,
       })
-    } else {
-      let data = getData(block.properties.find((p) => p.name === 'data'))
-      if (data) {
-        let format = getDataFormat(
-          block.properties.find((p) => p.name === 'format')
-        )
-        let validate = getDataValidate(
-          block.properties.find((p) => p.name === 'validate')
-        )
-
-        block.data = { ...data, format, validate }
-      }
     }
   }
 
@@ -536,14 +556,6 @@ export default ({
             })
             if (skipInvalidProps) continue
           }
-        }
-
-        if (name === 'onWhen' && properties.length > 0) {
-          warnings.push({
-            type: `Put onWhen at the top of the block. It's easier to see it that way!`,
-            line,
-            loc,
-          })
         }
 
         if (name === 'onWhen' && /!?isMedia.+/.test(slotName)) {


### PR DESCRIPTION
There is this use case for which it seems to always get the `value` from props instead of grabbing the data key:

```
Something View
is together
  Horizontal
  backgroundColor red
  data social_link.link
  when <value
  backgroundColor blue
```

the code generated looks something like this:

```
 style={{'--backgroundColor': value ? "rgb(53,80,164)" : "rgba(53,80,164,0.85)"}}
```

where the value is referenced from the props of the component.

I didn't find any usage of `when <value` in our codebase, so I am not sure if this is even a valid case. Do you think it should actually work and point to data path in this case?