### PR TITLE
fix: morph/react pass viewPath as a param to function

### DIFF
--- a/morph/react/get-body.js
+++ b/morph/react/get-body.js
@@ -38,7 +38,7 @@ export default function getBody({ state, name, view }) {
     ${state.useIsHovered ? getUseIsHovered({ state }) : ''}
     ${state.useIsMedia ? 'let isMedia = useIsMedia()' : ''}
     ${flow.join('\n')}
-    ${state.variables.join('\n')}
+    ${state.variables.join('\n').replace(/VIEW_PROPS/g, expandedProps)}
     ${animated.join('\n')}
 
   return ${ret}

--- a/morph/react/property-event-handler.js
+++ b/morph/react/property-event-handler.js
@@ -15,7 +15,9 @@ export function enter(node, parent, state) {
   // assuming it is a hook
   if (/^use[A-Z]/.test(node.value)) {
     let variableName = getVariableName(node.name, state)
-    state.variables.push(`let ${variableName} = ${importName}.${node.value}()`)
+    state.variables.push(
+      `let ${variableName} = ${importName}.${node.value}(VIEW_PROPS)`
+    )
     node.value = variableName
   } else {
     node.value = `${importName}.${node.value}`


### PR DESCRIPTION
I forgot to pass the `viewPath` so that it is used when calling `useData`