### PR TITLE
fix: morph/react pass viewPath as a param to function

### DIFF
--- a/morph/react/get-body.js
+++ b/morph/react/get-body.js
@@ -49,7 +49,7 @@ export default function getBody({ state, name, view }) {
     ${state.useIsHovered ? getUseIsHovered({ state }) : ''}
     ${state.useIsMedia ? 'let isMedia = useIsMedia()' : ''}
     ${flow.join('\n')}
-    ${state.variables.join('\n').replace(/VIEW_PROPS/g, expandedProps)}
+    ${state.variables.join('\n')}
     ${animated.join('\n')}
 
   return ${ret}

--- a/morph/react/get-expanded-props.js
+++ b/morph/react/get-expanded-props.js
@@ -21,12 +21,17 @@ let IGNORED_SLOTS = new Set([
   'isMediaMobile',
   'isMediaLaptop',
 ])
-export default function getExpandedProps({ state }) {
+export default function getExpandedProps({
+  state,
+  ignoreDefaultValues = false,
+}) {
   let slots = state.slots
     .filter((slot) => !IGNORED_SLOTS.has(slot.name))
     .map((slot) => {
       let maybeDefaultValue =
-        slot.defaultValue === false ? '' : `= ${stringify(slot)}`
+        slot.defaultValue === false || ignoreDefaultValues
+          ? ''
+          : `= ${stringify(slot)}`
       return `${slot.name}${maybeDefaultValue}`
     })
 

--- a/morph/react/property-event-handler.js
+++ b/morph/react/property-event-handler.js
@@ -16,7 +16,7 @@ export function enter(node, parent, state) {
   if (/^use[A-Z]/.test(node.value)) {
     let variableName = getVariableName(node.name, state)
     state.variables.push(
-      `let ${variableName} = ${importName}.${node.value}(VIEW_PROPS)`
+      `let ${variableName} = ${importName}.${node.value}({ viewPath })`
     )
     node.value = variableName
   } else {

--- a/morph/react/property-event-handler.js
+++ b/morph/react/property-event-handler.js
@@ -1,4 +1,5 @@
 import { getImportNameForSource, getVariableName } from '../utils.js'
+import getExpandedProps from './get-expanded-props.js'
 
 export function enter(node, parent, state) {
   if (
@@ -14,9 +15,10 @@ export function enter(node, parent, state) {
   let importName = getImportNameForSource(node.source, state)
   // assuming it is a hook
   if (/^use[A-Z]/.test(node.value)) {
+    let expandedProps = getExpandedProps({ state, ignoreDefaultValues: true })
     let variableName = getVariableName(node.name, state)
     state.variables.push(
-      `let ${variableName} = ${importName}.${node.value}({ viewPath })`
+      `let ${variableName} = ${importName}.${node.value}(${expandedProps})`
     )
     node.value = variableName
   } else {


### PR DESCRIPTION
@dariocravero I reverted it to the initial implementation because some of the params have default values assigned and this will result in a syntax error. Let me know please if you have an idea how to best handle it