### PR TITLE
feat: morph/react remove context name from data path

### DIFF
--- a/morph-all-view-graphql-files.js
+++ b/morph-all-view-graphql-files.js
@@ -145,16 +145,16 @@ ${isUsingDataTransform ? '  let data = useDataTransform(props, rdata)' : ''}
 ${isUsingDataOnChange ? '  let onChange = useDataOnChange(props, data)' : ''}
 ${isUsingDataOnSubmit ? '  let onSubmit = useDataOnSubmit(props, data)' : ''}
 
-  useSetFlowToBasedOnData({context: '${context}', data, ${
-      isQueryOperation ? 'fetching' : 'fetching: !data'
-    }, error, viewPath: props.viewPath, pause: ${
+  useSetFlowToBasedOnData({ data, ${
+    isQueryOperation ? 'fetching' : 'fetching: !data'
+  }, error, viewPath: props.viewPath, pause: ${
       isUsingDataConfiguration ? 'configuration.pause' : 'false'
     }})
 
   return (
     <DataProvider
       context="${context}"
-      value={data}
+      value={data?.${context}}
       viewPath={props.viewPath}
       ${isUsingDataOnChange ? 'onChange={onChange}' : ''}
       ${isUsingDataOnSubmit ? 'onSubmit={onSubmit}' : ''}

--- a/morph/react/block-list.js
+++ b/morph/react/block-list.js
@@ -90,7 +90,10 @@ function defaultItemDataContextName(node, from) {
   let value
   let data = getDataForLoc(node, from.loc)
   if (data && DATA_VALUE.test(from.value)) {
-    value = data.path.replace('.', '_')
+    value = [data.context, data.path]
+      .filter(Boolean)
+      .join('_')
+      .replace('.', '_')
   } else {
     value = from.value.replace('props.', '')
   }

--- a/morph/react/get-body.js
+++ b/morph/react/get-body.js
@@ -180,18 +180,12 @@ function getListItemDataProvider({ state, view }) {
 
   return `
   function ListItem(props) {
-    let value = React.useMemo(() => ({ [props.context]: props.item }), [
-      props.context,
-      props.item,
-    ])
     let valueItem = React.useMemo(() => ({
-      [\`\${props.context}_item\`]: {
-        index: props.index,
-        indexReverse: props.list.length - props.index,
-        isFirst: props.index === 0,
-        isLast: props.index === props.list.length - 1,
-      },
-    }), [props.context, props.index, props.list])
+      index: props.index,
+      indexReverse: props.list.length - props.index,
+      isFirst: props.index === 0,
+      isLast: props.index === props.list.length - 1,
+    }), [props.index, props.list])
     ${
       isUsingDataOnChange ? 'let onChange = useListItemDataOnChange(props)' : ''
     }
@@ -201,7 +195,7 @@ function getListItemDataProvider({ state, view }) {
     return (
       <fromData.DataProvider
       context={props.context}
-      value={value}
+      value={props.item}
       ${isUsingDataOnChange ? 'onChange={onChange}' : ''}
       ${isUsingDataOnSubmit ? 'onSubmit={onSubmit}' : ''}
       viewPath={props.viewPath}

--- a/parse/helpers.js
+++ b/parse/helpers.js
@@ -244,17 +244,18 @@ export let getData = (maybeProp) => {
   let match = `${maybeProp.value}`.match(/^((show|capture)\s+)?(.+)$/)
   if (!match) return null
 
-  let path = match[3]
-  if (/^\"(.+)?\"$/.test(path) || /^\'(.+)?\'$/.test(path)) {
+  let fullPath = match[3]
+  if (/^\"(.+)?\"$/.test(fullPath) || /^\'(.+)?\'$/.test(fullPath)) {
     return {
-      value: path,
+      value: fullPath,
       isConstant: true,
     }
   }
-  if (!isNaN(Number(path))) {
-    return { value: Number(path), isConstant: true }
+  if (!isNaN(Number(fullPath))) {
+    return { value: Number(fullPath), isConstant: true }
   }
-  let [context = null] = /\./.test(path) ? path.split('.') : [path]
+  let [context = null] = /\./.test(fullPath) ? fullPath.split('.') : [fullPath]
+  let path = context === fullPath ? null : fullPath.replace(`${context}.`, '')
 
   return { path, context }
 }


### PR DESCRIPTION
As this includes quite some changes in the applications to remove the context name from the data providers paths, I decided to address the next step in another PR rather than make all the changes in one go (i.e. extracting distinct hooks for different actions allowed to be done on data like `useDataValue`, `useDataFormat`, `useDataValidate` etc.).