### PR TITLE
fix: morph/react match data property exactly

### DIFF
--- a/morph/react-dom/get-value-for-property.js
+++ b/morph/react-dom/get-value-for-property.js
@@ -58,7 +58,7 @@ function getImageSource(node, parent, state) {
   }
 }
 
-let DATA_VALUES = /!?props\.(isInvalid|isInvalidInitial|isValid|isValidInitial|isSubmitting|value|onSubmit|onChange)/
+let DATA_VALUES = /!?props\.(isInvalid|isInvalidInitial|isValid|isValidInitial|isSubmitting|value|onSubmit|onChange)$/
 let CHILD_VALUES = /props\.(isSelected|isHovered|isFocused|isSelectedHovered)/
 let ON_IS_SELECTED = /(onClick|onPress|goTo)/
 

--- a/morph/react-native/get-value-for-property.js
+++ b/morph/react-native/get-value-for-property.js
@@ -59,7 +59,7 @@ function getImageSource(node, parent, state) {
   }
 }
 
-let DATA_VALUES = /!?props\.(isInvalid|isInvalidInitial|isValid|isValidInitial|isSubmitting|value|onSubmit|onChange)/
+let DATA_VALUES = /!?props\.(isInvalid|isInvalidInitial|isValid|isValidInitial|isSubmitting|value|onSubmit|onChange)$/
 let CHILD_VALUES = /props\.(isSelected|isHovered|isFocused|isSelectedHovered)/
 let ON_IS_SELECTED = /(onClick|onPress|goTo)/
 

--- a/morph/react/block-off-when.js
+++ b/morph/react/block-off-when.js
@@ -9,7 +9,7 @@ import {
 } from '../utils.js'
 
 let IS_MEDIA = /(!?props\.isMedia)(.+)/
-let DATA_VALUES = /!?props\.(isInvalid|isInvalidInitial|isValid|isValidInitial|isSubmitting|value)/
+let DATA_VALUES = /!?props\.(isInvalid|isInvalidInitial|isValid|isValidInitial|isSubmitting|value)$/
 let CHILD_VALUES = /!?props\.(isSelected|isHovered|isFocused)/
 let IS_HOVERED = /!?props\.(isHovered|isSelectedHovered)/
 let IS_FLOW = /!?props\.(isFlow|flow)$/

--- a/morph/utils.js
+++ b/morph/utils.js
@@ -118,7 +118,7 @@ function getScopedConditionPropValue(node, parent, state) {
 }
 
 let CHILD_VALUES = /!?props\.(isSelected|isHovered|isFocused|isSelectedHovered)/
-let DATA_VALUES = /!?props\.(isInvalid|isInvalidInitial|isValid|isValidInitial|value|isSubmitting)/
+let DATA_VALUES = /!?props\.(isInvalid|isInvalidInitial|isValid|isValidInitial|value|isSubmitting)$/
 let IS_HOVERED_OR_SELECTED_HOVER = /!?props\.(isHovered|isSelectedHovered)/
 let IS_FLOW = /!?props\.(isFlow|flow)$/
 export function isFlow(prop) {


### PR DESCRIPTION
* allow props to start with data reserved keywords e.g. valueSomething

There was a partial match on those keywords and as a result, as Neil discovered, it will end up referencing a data value instead of a prop e.g.

```
data some.data
selected <
text <valueSomething
```

it will be morphes as:

```
...
text={someData.valueSomething}
```
