### PR TITLE
feat: morph/react make use of granular functions when morphing data block

### DIFF
--- a/parse/helpers.js
+++ b/parse/helpers.js
@@ -249,15 +249,16 @@ export let getData = (maybeProp) => {
     return {
       value: fullPath,
       isConstant: true,
+      uses: new Set(),
     }
   }
   if (!isNaN(Number(fullPath))) {
-    return { value: Number(fullPath), isConstant: true }
+    return { value: Number(fullPath), isConstant: true, uses: new Set() }
   }
   let [context = null] = /\./.test(fullPath) ? fullPath.split('.') : [fullPath]
   let path = context === fullPath ? null : fullPath.replace(`${context}.`, '')
 
-  return { path, context }
+  return { path, context, uses: new Set() }
 }
 
 function maybeSourceAndValue(input) {


### PR DESCRIPTION
I tried to update the morphing of the data blocks so that instead of making use of the old `useData` function it will utilise the new granular functions which will be added in the other PR.