### PR TITLE
feat: morph/react support set flow based on data on separate views

### DIFF
--- a/morph/react-dom/block.js
+++ b/morph/react-dom/block.js
@@ -11,6 +11,7 @@ import * as BlockList from '../react/block-list.js'
 import * as BlockMaybeSkip from '../react/block-maybe-skip.js'
 import * as BlockName from './block-name.js'
 import * as BlockOffWhen from '../react/block-off-when.js'
+import * as BlockSetFlowToBasedOnData from '../react/block-set-flow-to-based-on-data.js'
 import * as BlockProfile from '../react/block-profile.js'
 import * as BlockProperties from './block-properties.js'
 import * as BlockSetTestId from '../react/block-set-test-id.js'
@@ -22,6 +23,7 @@ export let enter = [
   BlockSetTestId.enter,
   BlockAddData.enter,
   BlockOffWhen.enter,
+  BlockSetFlowToBasedOnData.enter,
 
   BlockName.enter,
   BlockProfile.enter,

--- a/morph/react-native/block.js
+++ b/morph/react-native/block.js
@@ -10,6 +10,7 @@ import * as BlockList from '../react/block-list.js'
 import * as BlockMaybeSkip from '../react/block-maybe-skip.js'
 import * as BlockName from './block-name.js'
 import * as BlockOffWhen from '../react/block-off-when.js'
+import * as BlockSetFlowToBasedOnData from '../react/block-set-flow-to-based-on-data.js'
 import * as BlockProfile from '../react/block-profile.js'
 import * as BlockProperties from './block-properties.js'
 import * as BlockSetTestId from '../react/block-set-test-id.js'
@@ -24,6 +25,7 @@ export let enter = [
   BlockAddData.enter,
   BlockOffWhen.enter,
   BlockWrap.enter,
+  BlockSetFlowToBasedOnData.enter,
 
   BlockName.enter,
   BlockProfile.enter,

--- a/morph/react/block-set-flow-to-based-on-data.js
+++ b/morph/react/block-set-flow-to-based-on-data.js
@@ -1,0 +1,160 @@
+import { getImportNameForSource } from '../utils'
+
+export function enter(node, parent, state) {
+  if (node.name !== 'View' || !node.setFlowToBasedOnData) return
+
+  if (isSetFlowToBasedOnDataIsSubmitting(node)) {
+    state.variables.push(
+      `fromData.useSetFlowToBasedOnDataIsSubmitting({ viewPath,`
+    )
+    maybeDataContext(node.setFlowToBasedOnData, state)
+    state.variables.push('})')
+  } else if (isSetFlowToBasedOnDataIsValid(node)) {
+    state.variables.push(`fromData.useSetFlowToBasedOnDataIsValid({ viewPath,`)
+    maybeDataContext(node.setFlowToBasedOnData, state)
+    maybeDataPath(node.setFlowToBasedOnData, state)
+    maybeDataValidate(node.setFlowToBasedOnData, state)
+    maybeDataCheckInitial(node.setFlowToBasedOnData, state)
+    state.variables.push('})')
+  } else if (isSetFlowToBasedOnDataIsInvalid(node)) {
+    state.variables.push(
+      `fromData.useSetFlowToBasedOnDataIsInvalid({ viewPath,`
+    )
+    maybeDataContext(node.setFlowToBasedOnData, state)
+    maybeDataPath(node.setFlowToBasedOnData, state)
+    maybeDataValidate(node.setFlowToBasedOnData, state)
+    maybeDataCheckInitial(node.setFlowToBasedOnData, state)
+    state.variables.push('})')
+  } else if (isSetFlowToBasedOnDataExists(node)) {
+    state.variables.push(`fromData.useSetFlowToBasedOnDataExists({ viewPath,`)
+    maybeDataContext(node.setFlowToBasedOnData, state)
+    maybeDataPath(node.setFlowToBasedOnData, state)
+    maybeDataFormat(node.setFlowToBasedOnData, state)
+    state.variables.push('})')
+  } else {
+    state.variables.push(`fromData.useSetFlowToBasedOnDataSwitch({ viewPath,`)
+    maybeDataContext(node.setFlowToBasedOnData, state)
+    maybeDataPath(node.setFlowToBasedOnData, state)
+    maybeDataFormat(node.setFlowToBasedOnData, state)
+    state.variables.push('})')
+  }
+
+  state.use('ViewsUseData')
+}
+
+function isSetFlowToBasedOnDataExists(node) {
+  return (
+    (!!node.setFlowToBasedOnData.content ||
+      node.children.some((child) => child.name === 'Content')) &&
+    node.children.length === 2
+  )
+}
+
+function isSetFlowToBasedOnDataIsSubmitting(node) {
+  return (
+    node.children.some((child) => child.name === 'IsSubmitting') &&
+    node.children.length === 2
+  )
+}
+
+function isSetFlowToBasedOnDataIsValid(node) {
+  return (
+    node.children.some((child) => child.name === 'IsValid') &&
+    node.children.length === 2
+  )
+}
+
+function isSetFlowToBasedOnDataIsInvalid(node) {
+  return (
+    node.children.some((child) => child.name === 'IsInvalid') &&
+    node.children.length === 2
+  )
+}
+
+function maybeDataContext(dataDefinition, state) {
+  if (dataDefinition.context === null) return
+
+  state.variables.push(`context: '${dataDefinition.context}',`)
+}
+
+function maybeDataPath(dataDefinition, state) {
+  if (!dataDefinition.path) return
+
+  state.variables.push(`path: '${dataDefinition.path}',`)
+}
+
+function maybeDataNo(dataDefinition, state) {
+  if (!dataDefinition.no) return
+
+  state.variables.push(`no: '${dataDefinition.no}',`)
+}
+
+function maybeDataContent(dataDefinition, state) {
+  if (!dataDefinition.content) return
+
+  state.variables.push(`content: '${dataDefinition.content}',`)
+}
+
+function maybeDataIsSubmitting(dataDefinition, state) {
+  if (!dataDefinition.isSubmitting) return
+
+  state.variables.push(`isSubmitting: '${dataDefinition.isSubmitting}',`)
+}
+
+function maybeDataIsValid(dataDefinition, state) {
+  if (!dataDefinition.isValid) return
+
+  state.variables.push(`isValid: '${dataDefinition.isValid}',`)
+}
+
+function maybeDataIsInvalid(dataDefinition, state) {
+  if (!dataDefinition.isInvalid) return
+
+  state.variables.push(`isInvalid: '${dataDefinition.isInvalid}',`)
+}
+
+function maybeDataCheckInitial(dataDefinition, state) {
+  if (
+    dataDefinition.checkInitial !== true &&
+    dataDefinition.checkInitial !== false
+  )
+    return
+
+  state.variables.push(`checkInitial: ${dataDefinition.checkInitial},`)
+}
+
+function maybeDataValidate(data, state) {
+  if (!data.validate) return
+
+  let importName = getValidateImportName(data.validate.source, state)
+  state.variables.push(`validate: ${importName}.${data.validate.value},`)
+}
+
+function maybeDataFormat(data, state) {
+  if (!data.format?.formatIn) return
+
+  let importName = getFormatImportName(data.format.formatIn.source, state)
+  state.variables.push(`format: ${importName}.${data.format.formatIn.value},`)
+}
+
+function getValidateImportName(source, state) {
+  let importName
+  if (source) {
+    importName = getImportNameForSource(source, state)
+  } else {
+    state.use('ViewsUseDataValidate')
+    importName = 'fromViewsValidate'
+  }
+  return importName
+}
+
+function getFormatImportName(source, state) {
+  let importName
+  if (source) {
+    importName = getImportNameForSource(source, state)
+  } else {
+    state.use('ViewsUseDataFormat')
+    importName = 'fromViewsFormat'
+  }
+  return importName
+}

--- a/parse/index.js
+++ b/parse/index.js
@@ -373,11 +373,52 @@ export default ({
       block.viewPath = path.dirname(file.replace(src.replace(/\\/g, '/'), ''))
       block.viewPathParent = path.dirname(block.viewPath)
 
+      if (flowProp.value === 'separate') {
+        parseViewSetFlowToBasedOnData(block)
+      }
+
       slots.push({
         name: 'viewPath',
         type: 'string',
         defaultValue: block.viewPath,
       })
+    }
+  }
+
+  function parseViewSetFlowToBasedOnData(block) {
+    let dataProp = block.properties.find((item) => item.name === 'data')
+    if (!dataProp) return
+    if (!dataProp.value) {
+      warnings.push({
+        type: 'Missing data context.',
+        loc: dataProp.loc,
+      })
+      return
+    }
+
+    let [context] = /\./.test(dataProp.value)
+      ? dataProp.value.split('.')
+      : [dataProp.value]
+    let path =
+      context === dataProp.value
+        ? null
+        : dataProp.value.replace(`${context}.`, '')
+
+    let validate = getDataValidate(
+      block.properties.find((item) => item.name === 'validate')
+    )
+    let format = getDataFormat(
+      block.properties.find((item) => item.name === 'format')
+    )
+
+    block.setFlowToBasedOnData = {
+      context,
+      path,
+      checkInitial: block.properties.find(
+        (item) => item.name === 'checkInitial'
+      )?.value,
+      validate,
+      format,
     }
   }
 

--- a/views/Data.tools.js
+++ b/views/Data.tools.js
@@ -14,6 +14,7 @@ import {
 } from './Flow.js'
 // import get from 'dlv';
 import get from 'lodash/get'
+import camelCase from 'lodash/camelCase'
 import produce from 'immer'
 // import set from 'dset';
 import set from 'lodash/set'
@@ -787,6 +788,250 @@ export function useSetFlowToBasedOnData({
     setFlowTo(normalizePath(viewPath, view))
   }, [data, error]) // eslint-disable-line
   // ignore setFlowTo and props.viewPath
+}
+
+export function useSetFlowToBasedOnDataExists({
+  context,
+  path = null,
+  format = null,
+  viewPath,
+}) {
+  let dataValue = useDataValue({ context, path, viewPath })
+  let setFlowTo = useSetFlowTo(viewPath)
+
+  let renderOneRef = useRef(false)
+
+  useDataListener({
+    context,
+    viewPath,
+    listener: (next, prev, flow, setFlowTo) => {
+      if (!renderOneRef.current) return
+
+      let value = path ? get(next, path) : next
+      let isContent = !!value
+      if (format) {
+        isContent = format(value)
+      }
+
+      let prevValue = path ? get(prev, path) : prev
+      let isContentPrev = !!prevValue
+      if (format) {
+        isContentPrev = format(prevValue)
+      }
+
+      let target = normalizePath(viewPath, isContent ? 'Content' : 'No')
+      if (isContent !== isContentPrev || !flow.has(target)) {
+        setFlowTo(target)
+      }
+    },
+  })
+
+  useEffect(() => {
+    let isContent = !!dataValue
+    if (format) {
+      isContent = format(dataValue)
+    }
+    let viewPathNext = normalizePath(viewPath, isContent ? 'Content' : 'No')
+    setFlowTo(viewPathNext)
+    renderOneRef.current = true
+  }, [viewPath]) //eslint-disable-line
+
+  return null
+}
+
+export function useSetFlowToBasedOnDataIsValid({
+  context,
+  path,
+  viewPath,
+  validate,
+  checkInitial = true,
+}) {
+  let dataIsValidInitial = useDataIsValidInitial({
+    context,
+    path,
+    validate,
+    viewPath,
+  })
+  let dataIsValid = useDataIsValid({
+    context,
+    path,
+    validate,
+    viewPath,
+  })
+
+  let setFlowTo = useSetFlowTo(viewPath)
+  let checkInitialRef = useRef(false)
+  let renderOneRef = useRef(false)
+
+  useDataListener({
+    context,
+    viewPath,
+    listener: (next, prev, flow, setFlowTo) => {
+      if (!renderOneRef.current) return
+
+      let value = path ? get(next, path) : next
+      let isContent = validate(value, value, next)
+
+      let prevValue = path ? get(prev, path) : prev
+      let isContentPrev = validate(prevValue, prevValue, prev)
+
+      let target = normalizePath(viewPath, isContent ? 'IsValid' : 'No')
+
+      if (
+        isContent !== isContentPrev ||
+        checkInitialRef.current ||
+        !flow.has(target)
+      ) {
+        setFlowTo(target)
+      }
+
+      if (checkInitialRef.current) {
+        checkInitialRef.current = false
+      }
+    },
+  })
+
+  useEffect(() => {
+    // on mount
+    let isContent = checkInitial ? dataIsValidInitial : dataIsValid
+    let target = normalizePath(viewPath, isContent ? 'IsValid' : 'No')
+    setFlowTo(target)
+    checkInitialRef.current = !checkInitial
+    renderOneRef.current = true
+  }, [viewPath]) //eslint-disable-line
+
+  return null
+}
+
+export function useSetFlowToBasedOnDataIsInvalid({
+  context,
+  path,
+  viewPath,
+  validate,
+  checkInitial = true,
+}) {
+  let dataIsValidInitial = useDataIsValidInitial({
+    context,
+    path,
+    validate,
+    viewPath,
+  })
+  let dataIsValid = useDataIsValid({
+    context,
+    path,
+    validate,
+    viewPath,
+  })
+
+  let setFlowTo = useSetFlowTo(viewPath)
+  let checkInitialRef = useRef(false)
+  let renderOneRef = useRef(false)
+
+  useDataListener({
+    context,
+    viewPath,
+    listener: (next, prev, flow, setFlowTo) => {
+      if (!renderOneRef.current) return
+
+      let value = path ? get(next, path) : next
+      let isContent = !validate(value, value, next)
+
+      let prevValue = path ? get(prev, path) : prev
+      let isContentPrev = !validate(prevValue, prevValue, prev)
+
+      let target = normalizePath(viewPath, isContent ? 'IsInvalid' : 'No')
+
+      if (
+        isContent !== isContentPrev ||
+        checkInitialRef.current ||
+        !flow.has(target)
+      ) {
+        setFlowTo(target)
+      }
+
+      if (checkInitialRef.current) {
+        checkInitialRef.current = false
+      }
+    },
+  })
+
+  useEffect(() => {
+    // on mount
+    let isContent = checkInitial ? !dataIsValidInitial : !dataIsValid
+    let target = normalizePath(viewPath, isContent ? 'IsInvalid' : 'No')
+    setFlowTo(target)
+    checkInitialRef.current = !checkInitial
+    renderOneRef.current = true
+  }, [viewPath]) //eslint-disable-line
+
+  return null
+}
+
+export function useSetFlowToBasedOnDataIsSubmitting({ context, viewPath }) {
+  let setFlowTo = useSetFlowTo(viewPath)
+  let dataIsSubmitting = useDataIsSubmitting({ context, viewPath })
+
+  // Does not need a register listener
+  // Review when merge into the morpher
+  useEffect(() => {
+    setFlowTo(normalizePath(viewPath, dataIsSubmitting ? 'IsSubmitting' : 'No'))
+  }, [viewPath, dataIsSubmitting]) //eslint-disable-line
+
+  return null
+}
+
+export function useSetFlowToBasedOnDataSwitch({
+  context,
+  path,
+  format,
+  viewPath,
+}) {
+  let dataValue = useDataFormat({
+    context,
+    path,
+    format,
+    viewPath,
+  })
+  let setFlowTo = useSetFlowTo(viewPath)
+  let renderOneRef = useRef(false)
+
+  useDataListener({
+    context,
+    viewPath,
+    listener: (next, prev, flow, setFlowTo) => {
+      if (!renderOneRef.current) return
+
+      let value = path ? get(next, path) : next
+      let view = format ? format(value, next) : capitalize(camelCase(value))
+
+      let prevValue = path ? get(prev, path) : prev
+      let viewPrev = format
+        ? format(prevValue, prev)
+        : capitalize(camelCase(prevValue))
+
+      let target = normalizePath(viewPath, view)
+      if (view !== viewPrev || !flow.has(target)) {
+        setFlowTo(target)
+      }
+    },
+  })
+
+  useEffect(() => {
+    setFlowTo(
+      normalizePath(
+        viewPath,
+        format ? dataValue : capitalize(camelCase(dataValue))
+      )
+    )
+    renderOneRef.current = true
+  }, [viewPath]) //eslint-disable-line
+
+  return null
+}
+
+function capitalize(value) {
+  if (!value || typeof value !== 'string') return ''
+  return value.charAt(0).toUpperCase() + value.slice(1)
 }
 
 function isEmpty(data) {


### PR DESCRIPTION
For now I let the keyword to be `data` as it seems people don't see it as a problem. We can go back to it and rename it if we find any issue.
Here is a small example for how that will look like:

```
LocationChooser View
is separate
data selected.parent_company_id
  No
  Content
```