### PR TITLE
fix: morph/react rename param checkInitial to validateInitial

### DIFF
--- a/morph/react/block-set-flow-to-based-on-data.js
+++ b/morph/react/block-set-flow-to-based-on-data.js
@@ -14,7 +14,7 @@ export function enter(node, parent, state) {
     maybeDataContext(node.setFlowToBasedOnData, state)
     maybeDataPath(node.setFlowToBasedOnData, state)
     maybeDataValidate(node.setFlowToBasedOnData, state)
-    maybeDataCheckInitial(node.setFlowToBasedOnData, state)
+    maybeDataValidateInitial(node.setFlowToBasedOnData, state)
     state.variables.push('})')
   } else if (isSetFlowToBasedOnDataIsInvalid(node)) {
     state.variables.push(
@@ -23,7 +23,7 @@ export function enter(node, parent, state) {
     maybeDataContext(node.setFlowToBasedOnData, state)
     maybeDataPath(node.setFlowToBasedOnData, state)
     maybeDataValidate(node.setFlowToBasedOnData, state)
-    maybeDataCheckInitial(node.setFlowToBasedOnData, state)
+    maybeDataValidateInitial(node.setFlowToBasedOnData, state)
     state.variables.push('})')
   } else if (isSetFlowToBasedOnDataExists(node)) {
     state.variables.push(`fromData.useSetFlowToBasedOnDataExists({ viewPath,`)
@@ -113,14 +113,14 @@ function maybeDataIsInvalid(dataDefinition, state) {
   state.variables.push(`isInvalid: '${dataDefinition.isInvalid}',`)
 }
 
-function maybeDataCheckInitial(dataDefinition, state) {
+function maybeDataValidateInitial(dataDefinition, state) {
   if (
-    dataDefinition.checkInitial !== true &&
-    dataDefinition.checkInitial !== false
+    dataDefinition.validateInitial !== true &&
+    dataDefinition.validateInitial !== false
   )
     return
 
-  state.variables.push(`checkInitial: ${dataDefinition.checkInitial},`)
+  state.variables.push(`validateInitial: ${dataDefinition.validateInitial},`)
 }
 
 function maybeDataValidate(data, state) {

--- a/parse/index.js
+++ b/parse/index.js
@@ -414,8 +414,8 @@ export default ({
     block.setFlowToBasedOnData = {
       context,
       path,
-      checkInitial: block.properties.find(
-        (item) => item.name === 'checkInitial'
+      validateInitial: block.properties.find(
+        (item) => item.name === 'validateInitial'
       )?.value,
       validate,
       format,

--- a/views/Data.js
+++ b/views/Data.js
@@ -477,7 +477,7 @@ export function useSetFlowToBasedOnDataIsValid({
   path,
   viewPath,
   validate,
-  checkInitial = true,
+  validateInitial = true,
 }) {
   let dataIsValidInitial = useDataIsValidInitial({
     context,
@@ -493,7 +493,7 @@ export function useSetFlowToBasedOnDataIsValid({
   })
 
   let setFlowTo = useSetFlowTo(viewPath)
-  let checkInitialRef = useRef(false)
+  let validateInitialRef = useRef(false)
   let renderOneRef = useRef(false)
 
   useDataListener({
@@ -512,24 +512,24 @@ export function useSetFlowToBasedOnDataIsValid({
 
       if (
         isContent !== isContentPrev ||
-        checkInitialRef.current ||
+        validateInitialRef.current ||
         !flow.has(target)
       ) {
         setFlowTo(target)
       }
 
-      if (checkInitialRef.current) {
-        checkInitialRef.current = false
+      if (validateInitialRef.current) {
+        validateInitialRef.current = false
       }
     },
   })
 
   useEffect(() => {
     // on mount
-    let isContent = checkInitial ? dataIsValidInitial : dataIsValid
+    let isContent = validateInitial ? dataIsValidInitial : dataIsValid
     let target = normalizePath(viewPath, isContent ? 'IsValid' : 'No')
     setFlowTo(target)
-    checkInitialRef.current = !checkInitial
+    validateInitialRef.current = !validateInitial
     renderOneRef.current = true
   }, [viewPath]) //eslint-disable-line
 
@@ -541,7 +541,7 @@ export function useSetFlowToBasedOnDataIsInvalid({
   path,
   viewPath,
   validate,
-  checkInitial = true,
+  validateInitial = true,
 }) {
   let dataIsValidInitial = useDataIsValidInitial({
     context,
@@ -557,7 +557,7 @@ export function useSetFlowToBasedOnDataIsInvalid({
   })
 
   let setFlowTo = useSetFlowTo(viewPath)
-  let checkInitialRef = useRef(false)
+  let validateInitialRef = useRef(false)
   let renderOneRef = useRef(false)
 
   useDataListener({
@@ -576,24 +576,24 @@ export function useSetFlowToBasedOnDataIsInvalid({
 
       if (
         isContent !== isContentPrev ||
-        checkInitialRef.current ||
+        validateInitialRef.current ||
         !flow.has(target)
       ) {
         setFlowTo(target)
       }
 
-      if (checkInitialRef.current) {
-        checkInitialRef.current = false
+      if (validateInitialRef.current) {
+        validateInitialRef.current = false
       }
     },
   })
 
   useEffect(() => {
     // on mount
-    let isContent = checkInitial ? !dataIsValidInitial : !dataIsValid
+    let isContent = validateInitial ? !dataIsValidInitial : !dataIsValid
     let target = normalizePath(viewPath, isContent ? 'IsInvalid' : 'No')
     setFlowTo(target)
-    checkInitialRef.current = !checkInitial
+    validateInitialRef.current = !validateInitial
     renderOneRef.current = true
   }, [viewPath]) //eslint-disable-line
 

--- a/views/Data.tools.js
+++ b/views/Data.tools.js
@@ -844,7 +844,7 @@ export function useSetFlowToBasedOnDataIsValid({
   path,
   viewPath,
   validate,
-  checkInitial = true,
+  validateInitial = true,
 }) {
   let dataIsValidInitial = useDataIsValidInitial({
     context,
@@ -860,7 +860,7 @@ export function useSetFlowToBasedOnDataIsValid({
   })
 
   let setFlowTo = useSetFlowTo(viewPath)
-  let checkInitialRef = useRef(false)
+  let validateInitialRef = useRef(false)
   let renderOneRef = useRef(false)
 
   useDataListener({
@@ -879,24 +879,24 @@ export function useSetFlowToBasedOnDataIsValid({
 
       if (
         isContent !== isContentPrev ||
-        checkInitialRef.current ||
+        validateInitialRef.current ||
         !flow.has(target)
       ) {
         setFlowTo(target)
       }
 
-      if (checkInitialRef.current) {
-        checkInitialRef.current = false
+      if (validateInitialRef.current) {
+        validateInitialRef.current = false
       }
     },
   })
 
   useEffect(() => {
     // on mount
-    let isContent = checkInitial ? dataIsValidInitial : dataIsValid
+    let isContent = validateInitial ? dataIsValidInitial : dataIsValid
     let target = normalizePath(viewPath, isContent ? 'IsValid' : 'No')
     setFlowTo(target)
-    checkInitialRef.current = !checkInitial
+    validateInitialRef.current = !validateInitial
     renderOneRef.current = true
   }, [viewPath]) //eslint-disable-line
 
@@ -908,7 +908,7 @@ export function useSetFlowToBasedOnDataIsInvalid({
   path,
   viewPath,
   validate,
-  checkInitial = true,
+  validateInitial = true,
 }) {
   let dataIsValidInitial = useDataIsValidInitial({
     context,
@@ -924,7 +924,7 @@ export function useSetFlowToBasedOnDataIsInvalid({
   })
 
   let setFlowTo = useSetFlowTo(viewPath)
-  let checkInitialRef = useRef(false)
+  let validateInitialRef = useRef(false)
   let renderOneRef = useRef(false)
 
   useDataListener({
@@ -943,24 +943,24 @@ export function useSetFlowToBasedOnDataIsInvalid({
 
       if (
         isContent !== isContentPrev ||
-        checkInitialRef.current ||
+        validateInitialRef.current ||
         !flow.has(target)
       ) {
         setFlowTo(target)
       }
 
-      if (checkInitialRef.current) {
-        checkInitialRef.current = false
+      if (validateInitialRef.current) {
+        validateInitialRef.current = false
       }
     },
   })
 
   useEffect(() => {
     // on mount
-    let isContent = checkInitial ? !dataIsValidInitial : !dataIsValid
+    let isContent = validateInitial ? !dataIsValidInitial : !dataIsValid
     let target = normalizePath(viewPath, isContent ? 'IsInvalid' : 'No')
     setFlowTo(target)
-    checkInitialRef.current = !checkInitial
+    validateInitialRef.current = !validateInitial
     renderOneRef.current = true
   }, [viewPath]) //eslint-disable-line
 


### PR DESCRIPTION
I just realised I forgot to rename the `checkInitial` param to `validateInitial` as discussed.