### PR TITLE
fix: morph/react prevent warnings in dev mode due to missing format

### DIFF
--- a/views/Data.js
+++ b/views/Data.js
@@ -617,7 +617,7 @@ export function useSetFlowToBasedOnDataIsSubmitting({ context, viewPath }) {
 export function useSetFlowToBasedOnDataSwitch({
   context,
   path,
-  format,
+  format = toCapitalisedCamelCase,
   viewPath,
 }) {
   let dataValue = useDataFormat({
@@ -636,12 +636,10 @@ export function useSetFlowToBasedOnDataSwitch({
       if (!renderOneRef.current) return
 
       let value = path ? get(next, path) : next
-      let view = format ? format(value, next) : capitalize(camelCase(value))
+      let view = format(value, next)
 
       let prevValue = path ? get(prev, path) : prev
-      let viewPrev = format
-        ? format(prevValue, prev)
-        : capitalize(camelCase(prevValue))
+      let viewPrev = format(prevValue, prev)
 
       let target = normalizePath(viewPath, view)
       if (view !== viewPrev || !flow.has(target)) {
@@ -651,16 +649,15 @@ export function useSetFlowToBasedOnDataSwitch({
   })
 
   useEffect(() => {
-    setFlowTo(
-      normalizePath(
-        viewPath,
-        format ? dataValue : capitalize(camelCase(dataValue))
-      )
-    )
+    setFlowTo(normalizePath(viewPath, dataValue))
     renderOneRef.current = true
   }, [viewPath]) //eslint-disable-line
 
   return null
+}
+
+function toCapitalisedCamelCase(value) {
+  return value && capitalize(camelCase(value))
 }
 
 function capitalize(value) {

--- a/views/Data.tools.js
+++ b/views/Data.tools.js
@@ -984,7 +984,7 @@ export function useSetFlowToBasedOnDataIsSubmitting({ context, viewPath }) {
 export function useSetFlowToBasedOnDataSwitch({
   context,
   path,
-  format,
+  format = toCapitalisedCamelCase,
   viewPath,
 }) {
   let dataValue = useDataFormat({
@@ -1003,12 +1003,10 @@ export function useSetFlowToBasedOnDataSwitch({
       if (!renderOneRef.current) return
 
       let value = path ? get(next, path) : next
-      let view = format ? format(value, next) : capitalize(camelCase(value))
+      let view = format(value, next)
 
       let prevValue = path ? get(prev, path) : prev
-      let viewPrev = format
-        ? format(prevValue, prev)
-        : capitalize(camelCase(prevValue))
+      let viewPrev = format(prevValue, prev)
 
       let target = normalizePath(viewPath, view)
       if (view !== viewPrev || !flow.has(target)) {
@@ -1018,16 +1016,15 @@ export function useSetFlowToBasedOnDataSwitch({
   })
 
   useEffect(() => {
-    setFlowTo(
-      normalizePath(
-        viewPath,
-        format ? dataValue : capitalize(camelCase(dataValue))
-      )
-    )
+    setFlowTo(normalizePath(viewPath, dataValue))
     renderOneRef.current = true
   }, [viewPath]) //eslint-disable-line
 
   return null
+}
+
+function toCapitalisedCamelCase(value) {
+  return value && capitalize(camelCase(value))
 }
 
 function capitalize(value) {


### PR DESCRIPTION
Due to using `useDataFormat` on the `useSetFlowToBasedOnDataSwitch` and sometimes no `format` function is provided (the view is derived straight from the data value) it would show some warnings in dev mode. Rather than passing the `__ignoreMissingInDevMode` flag to suppress those warnings I think it makes more sense to just have a default function (this is effectively what the logic does anyway, so I think it even makes the code more explicit).