### PR TITLE
fix: morph/react ignore data slots from view's props

### DIFF
--- a/morph/react-dom.js
+++ b/morph/react-dom.js
@@ -73,6 +73,7 @@ export default ({
       fromViewsValidate: 1,
       fromViewsAggregate: 1,
     },
+    ignoredExpandedProps: [],
     profile,
     uses: [],
     testIdKey: 'data-testid',

--- a/morph/react-native.js
+++ b/morph/react-native.js
@@ -79,6 +79,7 @@ export default ({
       fromViewsValidate: 1,
       fromViewsAggregate: 1,
     },
+    ignoredExpandedProps: [],
     uses: [],
     use(block, isLazy = false) {
       if (isLazy) {

--- a/morph/react/block-add-data.js
+++ b/morph/react/block-add-data.js
@@ -84,6 +84,9 @@ function addData(data, isAggregate, state) {
       maybeDataValidate(data, state)
       state.variables.push('})')
       data.variables.isValidInitial = dataIsValidInitialName
+
+      state.ignoredExpandedProps.push('isValidInitial')
+      state.ignoredExpandedProps.push('isInvalidInitial')
     }
 
     if (data.uses.has('useDataIsValid')) {
@@ -102,6 +105,9 @@ function addData(data, isAggregate, state) {
       }
       state.variables.push('})')
       data.variables.isValid = dataIsValidName
+
+      state.ignoredExpandedProps.push('isValid')
+      state.ignoredExpandedProps.push('isInvalid')
     }
   }
 
@@ -118,6 +124,8 @@ function addData(data, isAggregate, state) {
     maybeDataFormatOut(data, state)
     state.variables.push('})')
     data.variables.onChange = dataChangeName
+
+    state.ignoredExpandedProps.push('onChange')
   }
 
   if (data.uses.has('useDataSubmit')) {
@@ -131,6 +139,8 @@ function addData(data, isAggregate, state) {
     maybeDataContext(data, state)
     state.variables.push('})')
     data.variables.onSubmit = dataSubmitName
+
+    state.ignoredExpandedProps.push('onSubmit')
   }
 
   if (data.uses.has('useDataIsSubmitting')) {
@@ -144,6 +154,8 @@ function addData(data, isAggregate, state) {
     maybeDataContext(data, state)
     state.variables.push('})')
     data.variables.isSubmitting = dataIsSubmittingName
+
+    state.ignoredExpandedProps.push('isSubmitting')
   }
 
   state.use('ViewsUseData')

--- a/morph/react/get-expanded-props.js
+++ b/morph/react/get-expanded-props.js
@@ -27,6 +27,7 @@ export default function getExpandedProps({
 }) {
   let slots = state.slots
     .filter((slot) => !IGNORED_SLOTS.has(slot.name))
+    .filter((slot) => !state.ignoredExpandedProps.includes(slot.name))
     .map((slot) => {
       let maybeDefaultValue =
         slot.defaultValue === false || ignoreDefaultValues


### PR DESCRIPTION
With this PR I try to solve this issue where data related slots appear in the view's props as unused variables: https://github.com/viewstools/morph/issues/242

I need this change because I'll try to reuse the mechanism for the design tokens, otherwise it will even lead to syntax errors as the design token slots now contain dots as well:

```
color <ds.colors.primary
```

will end up with some code like this:

```
View({
viewPath,
... // other props
ds.colors.primary
}){ 
...
```

There could be an edge case issue with the approach, but I'm not expecting it to be a problem at the moment as those `isValid`, `onChange` etc. keywords should be used only with data anyway. e.g.

```
Some View
  Block
  isValid < # this should be passed through props here
  Block
  data something
  isValid < # this will correspond to the "data.isValid"
```

This use case will not work with the approach I implemented here, as the slot won't appear in the props. I couldn't think of a better solution, but let me know please if you think this could be problematic and we could dig into that more. Thanks


