### PR TITLE
feat: morph/react add support for design tokens

### DIFF
--- a/make-get-system-import.js
+++ b/make-get-system-import.js
@@ -8,6 +8,7 @@ let FILE_USE_DATA = path.join('Views', 'Data.js')
 let FILE_USE_DATA_FORMAT = path.join('Views', 'Data', 'format.js')
 let FILE_USE_DATA_VALIDATE = path.join('Views', 'Data', 'validate.js')
 let FILE_USE_DATA_AGGREGATE = path.join('Views', 'Data', 'aggregate.js')
+let FILE_USE_DESIGN_TOKENS = path.join('Views', 'DesignTokens.js')
 let FILE_USE_FLOW = path.join('Views', 'Flow.js')
 let FILE_USE_PROFILE = path.join('Views', 'Profile.js')
 let FILE_USE_STREAM = path.join('Views', 'Stream')
@@ -65,6 +66,13 @@ export default function makeGetSystemImport({ as, src }) {
         return `import * as fromViewsAggregate from '${relativise(
           file,
           path.join(src, FILE_USE_DATA_AGGREGATE),
+          src
+        )}'`
+
+      case 'ViewsUseDesignTokens':
+        return `import * as fromDesignTokens from '${relativise(
+          file,
+          path.join(src, FILE_USE_DESIGN_TOKENS),
           src
         )}'`
 

--- a/morph/react-dom.js
+++ b/morph/react-dom.js
@@ -73,6 +73,7 @@ export default ({
       fromViewsValidate: 1,
       fromViewsAggregate: 1,
     },
+    designTokenVariableName: {},
     profile,
     uses: [],
     testIdKey: 'data-testid',

--- a/morph/react-dom/block-properties.js
+++ b/morph/react-dom/block-properties.js
@@ -9,12 +9,14 @@ import * as PropertyStyle from '../react/property-style.js'
 import * as PropertyText from '../react/property-text.js'
 import * as PropertyViewPath from '../react/property-view-path.js'
 import * as PropertyEventHandler from '../react/property-event-handler.js'
+import * as PropertyDesignToken from '../react/properties-design-token.js'
 import { isColumn } from '../utils.js'
 import isValidPropertyForBlock from './is-valid-property-for-block.js'
 
 export function enter(node, parent, state) {
   if (node.isFragment) return false
 
+  PropertyDesignToken.enter(node, parent, state)
   PropertiesStyle.enter(node, parent, state)
   PropertiesClassName.enter(node, parent, state)
   PropertiesImage.enter(node, parent, state)

--- a/morph/react-dom/get-style-for-property.js
+++ b/morph/react-dom/get-style-for-property.js
@@ -10,6 +10,13 @@ import getUnit from '../get-unit.js'
 export default function getStyleForProperty(node, parent, state, code) {
   let scopedVar = setScopedVar(node, parent, state)
 
+  if (node.tags.designToken) {
+    return {
+      _isScoped: !!scopedVar,
+      [node.name]: asVar(node),
+    }
+  }
+
   if (scopedVar) {
     switch (node.name) {
       case 'rotate':

--- a/morph/react-dom/properties-style.js
+++ b/morph/react-dom/properties-style.js
@@ -85,7 +85,7 @@ function getDynamicCss({
   css,
 }) {
   let style = node.style.dynamic
-  if (!hasKeysInChildren(style)) return false
+  if (!hasKeysInChildren(style) && !hasDesignTokens(node)) return false
 
   state.cssDynamic = true
   node.styleName = node.nameFinal
@@ -95,10 +95,10 @@ function getDynamicCss({
       ` style={{${getAnimatedStyles(
         node,
         state.isReactNative
-      )},${getDynamicStyles(node)}}}`
+      )},${getDynamicStyles(node, state)}}}`
     )
   } else {
-    let inlineDynamicStyles = getDynamicStyles(node)
+    let inlineDynamicStyles = getDynamicStyles(node, state)
     if (inlineDynamicStyles) {
       state.render.push(` style={{${inlineDynamicStyles}}}`)
     }
@@ -114,6 +114,10 @@ function getDynamicCss({
         css
       )
     })
+}
+
+function hasDesignTokens(node) {
+  return !!node.properties.find((prop) => prop.tags.designToken)
 }
 
 function getAnimatedCss(node, css) {

--- a/morph/react-native.js
+++ b/morph/react-native.js
@@ -79,6 +79,7 @@ export default ({
       fromViewsValidate: 1,
       fromViewsAggregate: 1,
     },
+    designTokenVariableName: {},
     uses: [],
     use(block, isLazy = false) {
       if (isLazy) {

--- a/morph/react/block-add-data.js
+++ b/morph/react/block-add-data.js
@@ -1,7 +1,8 @@
-import toSnakeCase from 'to-snake-case'
-import toCamelCase from 'to-camel-case'
-
-import { getImportNameForSource, getVariableName } from '../utils.js'
+import {
+  getImportNameForSource,
+  getVariableName,
+  transformToCamelCase,
+} from '../utils.js'
 
 export function enter(node, parent, state) {
   for (let dataGroup of node.data) {
@@ -218,14 +219,4 @@ function getFormatImportName(source, state) {
 
 function getDataVariableName(params, state) {
   return getVariableName(transformToCamelCase([...params, 'data']), state)
-}
-
-function transformToCamelCase(args) {
-  return toCamelCase(
-    args
-      .filter(Boolean)
-      .map((arg) => arg.replace(/\./g, '_'))
-      .map(toSnakeCase)
-      .join('_')
-  )
 }

--- a/morph/react/properties-design-token.js
+++ b/morph/react/properties-design-token.js
@@ -1,0 +1,29 @@
+import { getVariableName, transformToCamelCase } from '../utils.js'
+
+export function enter(node, parent, state) {
+  let properties = [
+    ...node.properties,
+    ...node.scopes.flatMap((scope) => scope.properties),
+  ]
+  properties
+    .filter((prop) => prop.tags.designToken)
+    .forEach((prop) => {
+      let name = prop.tags.slot
+        ? prop.defaultValue
+        : prop.value.replace('props.', '')
+      if (state.designTokenVariableName[name]) return
+
+      let designTokenVariableName = getVariableName(
+        transformToCamelCase([name]),
+        state
+      )
+      state.variables
+        .push(`let ${designTokenVariableName} = fromDesignTokens.useDesignTokenValue({
+          viewPath,
+          path: '${name.replace('dt.', '')}'
+        })`)
+
+      state.designTokenVariableName[name] = designTokenVariableName
+      state.use('ViewsUseDesignTokens')
+    })
+}

--- a/parse/get-tags.js
+++ b/parse/get-tags.js
@@ -36,5 +36,11 @@ export default ({ name, isSlot, slotIsNot, value, block }) => {
 
   if (isFragment(name)) tags.fragment = true
 
+  if (isDesignToken(value)) tags.designToken = true
+
   return tags
+}
+
+function isDesignToken(value) {
+  return typeof value === 'string' && value.startsWith('dt.')
 }

--- a/parse/index.js
+++ b/parse/index.js
@@ -790,14 +790,18 @@ export default ({
             if (existingDefaultValue) {
               existingDefaultValue.name = slotName || name
               existingDefaultValue.type = getPropType(block, name, value)
-              existingDefaultValue.defaultValue = tags.shouldBeSlot
-                ? false
-                : propNode.defaultValue
+              existingDefaultValue.defaultValue =
+                tags.shouldBeSlot || tags.designToken
+                  ? false
+                  : propNode.defaultValue
             } else {
               block.slots.push({
                 name: slotName || name,
                 type: getPropType(block, name, value),
-                defaultValue: tags.shouldBeSlot ? false : propNode.defaultValue,
+                defaultValue:
+                  tags.shouldBeSlot || tags.designToken
+                    ? false
+                    : propNode.defaultValue,
               })
             }
           }

--- a/views/DesignTokens.js
+++ b/views/DesignTokens.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { DataProvider, useDataValue } from 'Views/Data.js'
+import get from 'lodash/get'
+import tokens from 'DesignSystem/tokens.json'
+
+let defaultTheme = Object.keys(tokens)[0]
+
+export function DesignTokens({ theme = defaultTheme, children, viewPath }) {
+  return (
+    <DataProvider
+      context="design_tokens_theme"
+      value={theme}
+      viewPath={viewPath}
+    >
+      {children}
+    </DataProvider>
+  )
+}
+
+export function useDesignTokenValue({ path, viewPath }) {
+  let theme = useDataValue({
+    context: 'design_tokens_theme',
+    viewPath,
+  })
+  return get(tokens, `${theme}.${path}`)
+}

--- a/views/DesignTokens.tools.js
+++ b/views/DesignTokens.tools.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import { DataProvider, useDataValue } from 'Views/Data.js'
+import get from 'lodash/get'
+import tokens from 'DesignSystem/tokens.json'
+
+let defaultTheme = Object.keys(tokens)[0]
+
+export function DesignTokens({ theme = defaultTheme, children, viewPath }) {
+  return (
+    <DataProvider
+      context="design_tokens_theme"
+      value={theme}
+      viewPath={viewPath}
+    >
+      {children}
+    </DataProvider>
+  )
+}
+
+export function useDesignTokenValue({ path, viewPath }) {
+  let theme = useDataValue({
+    context: 'design_tokens_theme',
+    viewPath,
+  })
+  let token = get(tokens, `${theme}.${path}`)
+  if (process.env.NODE_ENV === 'development') {
+    if (!token) {
+      debug({
+        type: 'views/design-tokens/missing-design-token',
+        viewPath,
+        message: `You're missing the design token "${path}" for the theme "${theme}". Please add it to your project's design-tokens.json file.`,
+      })
+    }
+  }
+  return token
+}
+
+let logQueue = []
+let logTimeout = null
+function debug(stuff) {
+  logQueue.push(stuff)
+  clearTimeout(logTimeout)
+  logTimeout = setTimeout(() => {
+    if (logQueue.length > 0) {
+      console.debug({
+        type: 'views/data',
+        warnings: logQueue,
+      })
+      logQueue = []
+    }
+  }, 500)
+}


### PR DESCRIPTION
With these change support was added for design tokens. In order the make use of the design tokens an application should be wrapped by the `ThemeDesignTokensProvider` like this:

```
  import design_tokens from 'DesignSystem/design-tokens.json'

  <ThemeDesignTokensProvider
    theme="light"
    design_tokens={design_tokens}
  >
    ...
  </ThemeDesignTokensProvider>
```

Let me know if you think this approach is not right or there is a better way and we can discuss.

Here are a couple of cases supported with this approach:

## Simple reference to a design token:

```
  backgroundColor dt.colors.primary
```

morphed as:

```
let dtColorsPrimary = fromData.useDesignTokenValue({ viewPath, path: 'colors.primary' })
...
 style={{'--backgroundColor': dtColorsPrimary}}
...
```

## Reference to a design token and allow to override through component props:

```
  backgroundColor < dt.colors.primary
```

morphed as:

```
... // other props
backgroundColor
}) {
let dtColorsPrimary = fromData.useDesignTokenValue({ viewPath, path: 'colors.primary' })
...
 style={{'--backgroundColor':  backgroundColor || dtColorsPrimary}}
...
```

## With `when` conditions:

```
  backgroundColor dt.colors.primary
  when <isMediaMobile
  backgroundColor dt.colors.secondary
```
will be morphed to:
```
  let isMedia = useIsMedia()
  let dtColorsPrimary = fromData.useDesignTokenValue({viewPath, path: 'colors.primary' })
  let dtColorsSecondary = fromData.useDesignTokenValue({ viewPath, path: 'colors.secondary' })
...
 style={{'--backgroundColor': isMedia.mobile ? dtColorsSecondary : dtColorsPrimary}}
...
```

## With `when` conditions and override through component props:

```
  backgroundColor < dt.colors.primary
  when <isMediaMobile
  backgroundColor <secondaryBackgroundColor dt.colors.secondary
```
will be morphed to:
```
backgroundColor,
secondaryBackgroundColor
}) {
  let isMedia = useIsMedia()
  let dtColorsPrimary = fromData.useDesignTokenValue({ viewPath, path: 'colors.primary' })
  let dtColorsSecondary = fromData.useDesignTokenValue({ viewPath, path: 'colors.secondary' })
...
 style={{'--backgroundColor': isMedia.mobile ? secondaryBackgroundColor || dtColorsSecondary : backgroundColor || dtColorsPrimary}}
...
```

In this case it will take into account first the prop and, if not specified, will default to the design token value.
