### PR TITLE
fix: include list item key in the view path of the list elements

### DIFF
--- a/morph/react/block-in-list.js
+++ b/morph/react/block-in-list.js
@@ -1,4 +1,4 @@
-import { getProp, isList } from '../utils.js'
+import { getListItemKey, getProp, hasProp, isList } from '../utils.js'
 
 export function enter(node, parent, state) {
   if (!isList(parent)) return
@@ -10,8 +10,12 @@ export function enter(node, parent, state) {
   state.render.push(` item={item}`)
 
   if (state.viewPath) {
+    let key = hasProp(parent, 'itemKey')
+      ? getListItemKey(parent)
+      : `item?.id || index`
+
     state.render.push(
-      ` viewPath={\`$\{props.viewPath}/${node.name}($\{item?.id || index})\`}`
+      ` viewPath={\`$\{props.viewPath}/${node.name}($\{${key}})\`}`
     )
     node.skipViewPath = true
   }

--- a/morph/react/block-list.js
+++ b/morph/react/block-list.js
@@ -6,6 +6,7 @@ import {
   replacePropWithDataValue,
   isList,
   hasProp,
+  getListItemKey,
 } from '../utils.js'
 
 let DATA_VALUE = /props\.value/
@@ -59,14 +60,7 @@ export function enter(node, parent, state) {
       defaultItemDataContextName(node, from)
     let key
     if (hasProp(node, 'itemKey')) {
-      let elements = getProp(node, 'itemKey')
-        .value.split(',')
-        .map((key) => key.trim())
-      key = `\`${elements
-        .map((key) =>
-          /[^A-Za-z_]/.test(key) ? `$\{item?.["${key}"]}` : `$\{item?.${key}}`
-        )
-        .join('-')}\``
+      key = getListItemKey(node)
     } else {
       key = `item?.id || index`
 

--- a/morph/utils.js
+++ b/morph/utils.js
@@ -752,3 +752,14 @@ export function transformToCamelCase(args) {
       .join('_')
   )
 }
+
+export function getListItemKey(node) {
+  let elements = getProp(node, 'itemKey')
+    .value.split(',')
+    .map((key) => key.trim())
+  return `\`${elements
+    .map((key) =>
+      /[^A-Za-z_]/.test(key) ? `$\{item?.["${key}"]}` : `$\{item?.${key}}`
+    )
+    .join('-')}\``
+}


### PR DESCRIPTION
A made a small change as the `viewPath` of an item in a list was still `item?.id || index`, I think it makes more sense to be consistent and use the same generated key.