### PR TITLE
fix: prevent syntax error when using list component in design system

### DIFF
--- a/morph/react/block-list.js
+++ b/morph/react/block-list.js
@@ -58,24 +58,8 @@ export function enter(node, parent, state) {
     let itemDataContextName =
       getProp(node, 'itemDataContextName') ||
       defaultItemDataContextName(node, from)
-    let key
-    if (hasProp(node, 'itemKey')) {
-      key = getListItemKey(node)
-    } else {
-      key = `item?.id || index`
-
-      if (state.tools) {
-        state.render.push(`
-          if (process.env.NODE_ENV === 'development') {
-            if(!item?.id) {
-              console.debug({
-                type: 'views/data',
-                warning: \`Missing "id" property on the item $\{JSON.stringify(item)} in context "${itemDataContextName.value}" so the index in the list will be used as a fallback key. Consider setting "itemKey" if the item has a custom or compound key e.g.  first_name,last_name.\`,
-              })
-            }
-          }`)
-      }
-    }
+    let hasItemKey = hasProp(node, 'itemKey')
+    let key = hasItemKey ? getListItemKey(node) : `item?.id || index`
 
     state.render.push(
       `return <ListItem
@@ -84,6 +68,7 @@ export function enter(node, parent, state) {
         item={item}
         index={index}
         list={list}
+        hasItemKey={${hasItemKey}}
         viewPath={\`$\{props.viewPath}/${node.children[0].name}($\{${key}})\`}
       >`
     )

--- a/morph/react/get-body.js
+++ b/morph/react/get-body.js
@@ -193,6 +193,17 @@ function getListItemDataProvider({ state, view }) {
     ${
       isUsingDataOnSubmit ? 'let onSubmit = useListItemDataOnSubmit(props)' : ''
     }
+    ${
+      state.tools
+        ? `
+    if (process.env.NODE_ENV === 'development' && !props.hasItemKey && !props.item?.id) {
+      console.debug({
+        type: 'views/data',
+        warning: \`Missing "id" property on the item $\{JSON.stringify(props.item)} in context "\${props.context}" so the index in the list will be used as a fallback key. Consider setting "itemKey" if the item has a custom or compound key e.g.  first_name,last_name.\`,
+      })
+    }`
+        : ''
+    }
     return (
       <fromData.DataProvider
       context={props.context}


### PR DESCRIPTION
I completely forgot we're using List also in DS for some projects, so code morphed has a syntax error as the iterator function doesn't have a return statement. I moved the warning displayed when the items in the list don't have an id inside the ListItem component and with that approach it should work fine.