### PR TITLE
feat: pass originalValue as a param to DataProvider's onSubmit function

### DIFF
--- a/views/Data.js
+++ b/views/Data.js
@@ -192,6 +192,7 @@ export function DataProvider(props) {
       dispatch({ type: IS_SUBMITTING, value: true })
       let res = await onSubmit.current({
         value: stateRef.current.value,
+        originalValue: props.value,
         args,
         change: _change,
       })

--- a/views/Data.tools.js
+++ b/views/Data.tools.js
@@ -231,6 +231,7 @@ export function DataProvider(props) {
       dispatch({ type: IS_SUBMITTING, value: true })
       let res = await onSubmit.current({
         value: stateRef.current.value,
+        originalValue: props.value,
         args,
         change: _change,
       })


### PR DESCRIPTION
@CamilaSau came up with a use case requiring comparing the current with the previous value on the onSubmit function and she proposed to pass the originalValue as a param in addition to the current value. I think it makes sense, so added this small PR, but let me know if there is anything I may have missed