### PR TITLE
fix: ignore react native invalid style props

### DIFF
--- a/morph/react-native/properties-style.js
+++ b/morph/react-native/properties-style.js
@@ -1,3 +1,4 @@
+import chalk from 'chalk'
 import { enter } from '../react/properties-style.js'
 import {
   createId,
@@ -7,6 +8,225 @@ import {
   getNonAnimatedDynamicStyles,
   hasKeys,
 } from '../utils.js'
+
+let TEXT_PROPS = [
+  'display',
+  'width',
+  'height',
+  'start',
+  'end',
+  'top',
+  'left',
+  'right',
+  'bottom',
+  'minWidth',
+  'maxWidth',
+  'minHeight',
+  'maxHeight',
+  'margin',
+  'marginVertical',
+  'marginHorizontal',
+  'marginTop',
+  'marginBottom',
+  'marginLeft',
+  'marginRight',
+  'marginStart',
+  'marginEnd',
+  'padding',
+  'paddingVertical',
+  'paddingHorizontal',
+  'paddingTop',
+  'paddingBottom',
+  'paddingLeft',
+  'paddingRight',
+  'paddingStart',
+  'paddingEnd',
+  'borderWidth',
+  'borderTopWidth',
+  'borderStartWidth',
+  'borderEndWidth',
+  'borderRightWidth',
+  'borderBottomWidth',
+  'borderLeftWidth',
+  'position',
+  'flexDirection',
+  'flexWrap',
+  'justifyContent',
+  'alignItems',
+  'alignSelf',
+  'alignContent',
+  'overflow',
+  'flex',
+  'flexGrow',
+  'flexShrink',
+  'flexBasis',
+  'aspectRatio',
+  'zIndex',
+  'direction',
+  'shadowColor',
+  'shadowOffset',
+  'shadowOpacity',
+  'shadowRadius',
+  'transform',
+  'transformMatrix',
+  'decomposedMatrix',
+  'scaleX',
+  'scaleY',
+  'rotation',
+  'translateX',
+  'translateY',
+  'backfaceVisibility',
+  'backgroundColor',
+  'borderColor',
+  'borderTopColor',
+  'borderRightColor',
+  'borderBottomColor',
+  'borderLeftColor',
+  'borderStartColor',
+  'borderEndColor',
+  'borderRadius',
+  'borderTopLeftRadius',
+  'borderTopRightRadius',
+  'borderTopStartRadius',
+  'borderTopEndRadius',
+  'borderBottomLeftRadius',
+  'borderBottomRightRadius',
+  'borderBottomStartRadius',
+  'borderBottomEndRadius',
+  'borderStyle',
+  'opacity',
+  'elevation',
+  'color',
+  'fontFamily',
+  'fontSize',
+  'fontStyle',
+  'fontWeight',
+  'fontVariant',
+  'textShadowOffset',
+  'textShadowRadius',
+  'textShadowColor',
+  'letterSpacing',
+  'lineHeight',
+  'textAlign',
+  'textAlignVertical',
+  'includeFontPadding',
+  'textDecorationLine',
+  'textDecorationStyle',
+  'textDecorationColor',
+  'textTransform',
+  'writingDirection',
+]
+
+let VIEW_PROPS = [
+  'alignContent',
+  'alignItems',
+  'alignSelf',
+  'aspectRatio',
+  'backfaceVisibility',
+  'backgroundColor',
+  'borderBottomColor',
+  'borderBottomEndRadius',
+  'borderBottomLeftRadius',
+  'borderBottomRightRadius',
+  'borderBottomStartRadius',
+  'borderBottomWidth',
+  'borderColor',
+  'borderEndColor',
+  'borderEndWidth',
+  'borderLeftColor',
+  'borderLeftWidth',
+  'borderRadius',
+  'borderRightColor',
+  'borderRightWidth',
+  'borderStartColor',
+  'borderStartWidth',
+  'borderStyle',
+  'borderTopColor',
+  'borderTopEndRadius',
+  'borderTopLeftRadius',
+  'borderTopRightRadius',
+  'borderTopStartRadius',
+  'borderTopWidth',
+  'borderWidth',
+  'bottom',
+  'color',
+  'decomposedMatrix',
+  'direction',
+  'display',
+  'elevation',
+  'end',
+  'flex',
+  'flexBasis',
+  'flexDirection',
+  'flexGrow',
+  'flexShrink',
+  'flexWrap',
+  'fontFamily',
+  'fontSize',
+  'fontStyle',
+  'fontVariant',
+  'fontWeight',
+  'height',
+  'includeFontPadding',
+  'justifyContent',
+  'left',
+  'letterSpacing',
+  'lineHeight',
+  'margin',
+  'marginBottom',
+  'marginEnd',
+  'marginHorizontal',
+  'marginLeft',
+  'marginRight',
+  'marginStart',
+  'marginTop',
+  'marginVertical',
+  'maxHeight',
+  'maxWidth',
+  'minHeight',
+  'minWidth',
+  'opacity',
+  'overflow',
+  'overlayColor',
+  'padding',
+  'paddingBottom',
+  'paddingEnd',
+  'paddingHorizontal',
+  'paddingLeft',
+  'paddingRight',
+  'paddingStart',
+  'paddingTop',
+  'paddingVertical',
+  'position',
+  'resizeMode',
+  'right',
+  'rotation',
+  'scaleX',
+  'scaleY',
+  'shadowColor',
+  'shadowOffset',
+  'shadowOpacity',
+  'shadowRadius',
+  'start',
+  'textAlign',
+  'textAlignVertical',
+  'textDecorationColor',
+  'textDecorationLine',
+  'textDecorationStyle',
+  'textShadowColor',
+  'textShadowOffset',
+  'textShadowRadius',
+  'textTransform',
+  'tintColor',
+  'top',
+  'transform',
+  'transformMatrix',
+  'translateX',
+  'translateY',
+  'width',
+  'writingDirection',
+  'zIndex',
+]
 
 export { enter }
 
@@ -30,7 +250,19 @@ export let leave = (node, parent, state) => {
   if (hasKeys(node.style.static.base)) {
     let id = createId(node, state)
 
-    state.styles[id] = node.style.static.base
+    let blockType = node.is || node.name
+    let handleBlockTypes = ['Text', 'Horizontal', 'Vertical']
+    if (handleBlockTypes.includes(blockType)) {
+      state.styles[id] = filterInvalidStyles(
+        node.style.static.base,
+        blockType === 'Text' ? TEXT_PROPS : VIEW_PROPS,
+        node,
+        state
+      )
+    } else {
+      state.styles[id] = node.style.static.base
+    }
+
     baseStyle = `styles.${id}`
   }
 
@@ -132,4 +364,25 @@ export let leave = (node, parent, state) => {
   if (containerStyle) {
     state.render.push(` contentContainerStyle={${containerStyle}}`)
   }
+}
+
+function filterInvalidStyles(styles, validStyles, node, state) {
+  let result = {}
+  for (let key of Object.keys(styles)) {
+    if (validStyles.includes(key)) {
+      result[key] = styles[key]
+    } else {
+      printWarning(
+        `Ignoring unrecognized style property "${key}: ${styles[key]}"`,
+        node.is || node.name,
+        state.viewPath
+      )
+    }
+  }
+  return result
+}
+
+function printWarning(warning, nodeName, viewPath) {
+  console.error(chalk.red(nodeName), chalk.dim(viewPath))
+  console.error(`  ${chalk.blue(warning)}`)
 }


### PR DESCRIPTION
With these changes the morpher will ignore the style properties that are not valid for React Native's Text and View components.