### PR TITLE
fix: prevent issue with component name already used in import

### DIFF
--- a/morph/react-native.js
+++ b/morph/react-native.js
@@ -139,7 +139,7 @@ export default ({
         designSystemImportRoot,
       }),
       getStyles,
-      name: finalName,
+      name: state.name,
       state,
       view,
     }),


### PR DESCRIPTION
e.g. it will generate something like this for the views with a No/Content/Loading/etc. pattern:

```
import Content from './Content/view.js'
import Empty from './Empty/view.js'
import Error from './Error/view.js'
import Loading from './Loading/view.js'
import No from './No/view.js'
import React from 'react'



export default function Content({....
```

hence throwing an error as the component name is `Content` and there is already an import `Content`. It works fine already for react-dom