### PR TITLE
fix: reference expanded props from animation scoped conditions

### DIFF
--- a/morph/react/get-body.js
+++ b/morph/react/get-body.js
@@ -132,8 +132,10 @@ function getAnimated({ state }) {
               ? scope.value
               : `${scope.value}${unit}`
             : scope.value
-
-          return `${condition}? ${JSON.stringify(value)} : ${current}`
+          let elseValue = current.startsWith('"props.')
+            ? current.substring(1, current.length - 1).replace('props.', '')
+            : current.replace('props.', '')
+          return `${condition} ? ${JSON.stringify(value)} : ${elseValue}`
         }, JSON.stringify(propValue))
 
         toValue.push(`${JSON.stringify(prop.name)}: ${value}`)


### PR DESCRIPTION
Sometimes I found that for animations it was referencing the props through e.g. `props.isInvalid` instead of directly referencing the expanded prop so it results in an error as props is not defined.