### PR TITLE
fix: add value param to onChange for react native TextInput

### DIFF
--- a/morph/react-dom/get-value-for-property.js
+++ b/morph/react-dom/get-value-for-property.js
@@ -156,6 +156,16 @@ export default function getValueForProperty(node, parent, state) {
         [node.name]: safe(node.value, node),
       }
     }
+  } else if (
+    ['Capture', 'CaptureTextArea'].includes(parent.name) &&
+    node.name === 'onChange'
+  ) {
+    return {
+      [node.name]: safe(
+        `(e) => ${node.value} && ${node.value}(e, e.target.value)`,
+        node
+      ),
+    }
   } else {
     return {
       [node.name]: safe(node.value, node),

--- a/morph/react-native/get-value-for-property.js
+++ b/morph/react-native/get-value-for-property.js
@@ -156,6 +156,17 @@ export default function getValueForProperty(node, parent, state) {
         [node.name]: safe(node.value, node),
       }
     }
+  } else if (
+    ['Capture', 'CaptureTextArea'].includes(parent.name) &&
+    node.name === 'onChange'
+  ) {
+    // adding the value as a second argument to onChange as the event received if different on React DOM from React Native
+    return {
+      [node.name]: safe(
+        `(e) => ${node.value} && ${node.value}(e, e.nativeEvent.text)`,
+        node
+      ),
+    }
   } else {
     return {
       [node.name]: safe(node.value, node),


### PR DESCRIPTION
* the client using this method will have to always get the value from the onChange's second param for the code to work the same way regardless of the target platform