### PR TITLE
fix: custom hook to record if input field is focused

### DIFF
--- a/make-get-system-import.js
+++ b/make-get-system-import.js
@@ -3,6 +3,7 @@ import path from 'path'
 
 let FILE_USE_IS_BEFORE = path.join('Views', 'hooks', 'useIsBefore.js')
 let FILE_USE_IS_HOVERED = path.join('Views', 'hooks', 'useIsHovered.js')
+let FILE_USE_IS_FOCUSED = path.join('Views', 'hooks', 'useIsFocused.js')
 let FILE_USE_IS_MEDIA = path.join('Views', 'hooks', 'useIsMedia.js')
 let FILE_USE_DATA = path.join('Views', 'Data.js')
 let FILE_USE_DATA_FORMAT = path.join('Views', 'Data', 'format.js')
@@ -38,6 +39,13 @@ export default function makeGetSystemImport({ as, src }) {
         return `import useIsHovered from '${relativise(
           file,
           path.join(src, FILE_USE_IS_HOVERED),
+          src
+        )}'`
+
+      case 'ViewsUseIsFocused':
+        return `import useIsFocused from '${relativise(
+          file,
+          path.join(src, FILE_USE_IS_FOCUSED),
           src
         )}'`
 

--- a/morph/react-native/get-value-for-property.js
+++ b/morph/react-native/get-value-for-property.js
@@ -62,6 +62,7 @@ function getImageSource(node, parent, state) {
 let DATA_VALUES = /!?props\.(isInvalid|isInvalidInitial|isValid|isValidInitial|isSubmitting|value|onSubmit|onChange)$/
 let CHILD_VALUES = /props\.(isSelected|isHovered|isFocused|isSelectedHovered)/
 let ON_IS_SELECTED = /(onClick|onPress|goTo)/
+let ON_IS_FOCUSED = /(onFocus|onBlur)/
 
 export default function getValueForProperty(node, parent, state) {
   let data = getDataForLoc(parent, node.loc)
@@ -166,6 +167,11 @@ export default function getValueForProperty(node, parent, state) {
         `(e) => ${node.value} && ${node.value}(e, e.nativeEvent.text)`,
         node
       ),
+    }
+  } else if (parent.isBasic && ON_IS_FOCUSED.test(node.name)) {
+    state.useIsFocused = true
+    return {
+      [node.name]: safe(`${node.value.replace('props.', '')}Bind`, node),
     }
   } else {
     return {

--- a/morph/react/get-body.js
+++ b/morph/react/get-body.js
@@ -3,6 +3,7 @@ import { getScopedName } from '../utils.js'
 import getUnit from '../get-unit.js'
 import getExpandedProps from './get-expanded-props.js'
 import getUseIsHovered from './get-use-is-hovered.js'
+import getUseIsFocused from './get-use-is-focused.js'
 import path from 'path'
 
 export default function getBody({ state, name, view }) {
@@ -51,6 +52,7 @@ export default function getBody({ state, name, view }) {
       state.isDesignSystemRoot && `  let viewPath = "${state.viewPath}"`,
       state.useIsBefore && '  let isBefore = useIsBefore()',
       state.useIsHovered && getUseIsHovered({ state }),
+      state.useIsFocused && getUseIsFocused({ state }),
       state.useIsMedia && '  let isMedia = useIsMedia()',
       ...flow,
       ...state.variables,

--- a/morph/react/get-dependencies.js
+++ b/morph/react/get-dependencies.js
@@ -147,6 +147,10 @@ export default (state, getImport, file) => {
     dependencies.push(getImport('ViewsUseIsHovered'))
   }
 
+  if (state.useIsFocused) {
+    dependencies.push(getImport('ViewsUseIsFocused'))
+  }
+
   if (state.useIsMedia) {
     dependencies.push(getImport('ViewsUseIsMedia'))
   }

--- a/morph/react/get-use-is-focused.js
+++ b/morph/react/get-use-is-focused.js
@@ -1,0 +1,11 @@
+let FOCUSED_PROPS = new Set(['isFocused', 'onFocus', 'onBlur'])
+
+export default function getUseIsFocused({ state }) {
+  let focusedProps = state.slots
+    .filter((slot) => FOCUSED_PROPS.has(slot.name))
+    .map((slot) => slot.name)
+
+  return `let [isFocused, onFocusBind, onBlurBind] = useIsFocused({${focusedProps.join(
+    ','
+  )}})`
+}

--- a/views/hooks/useIsFocused.js
+++ b/views/hooks/useIsFocused.js
@@ -1,0 +1,22 @@
+import { useCallback, useState } from 'react'
+
+export default function useIsFocused({ onFocus, onBlur }) {
+  let [isFocused, setIsFocused] = useState(false)
+
+  let onFocusBind = useCallback(
+    (e) => {
+      setIsFocused(true)
+      onFocus && onFocus(e)
+    },
+    [onFocus]
+  )
+  let onBlurBind = useCallback(
+    (e) => {
+      setIsFocused(false)
+      onBlur && onBlur(e)
+    },
+    [onBlur]
+  )
+
+  return [isFocused, onFocusBind, onBlurBind]
+}


### PR DESCRIPTION
As suggested, I followed the same approach as for `isHovered` and with these changes it should enable making use of `isFocused` conditions in animations.