### PR TITLE
feat: import module without `.js` extension

### DIFF
--- a/morph/react/make-get-import.js
+++ b/morph/react/make-get-import.js
@@ -47,7 +47,10 @@ function ${id}() {
 }`
     }
 
-    let importPath = relativise(view.file, importView.importFile, src)
+    let importPath = relativise(view.file, importView.importFile, src).replace(
+      '.js',
+      ''
+    )
 
     if (designSystemImportRoot && importPath.startsWith('DesignSystem')) {
       importPath = importPath.replace('DesignSystem', designSystemImportRoot)


### PR DESCRIPTION
* will enable importing platform specific files such as `Logic.native.js` for React Native

With this change, the import of the files generated by the morpher will look something like this:

```
import Logic from './logic'
import View from './view'
```

so for React Native, if there is a file named `logic.native.js` it will be picked up by default. I did some testing by following the RN documentation here https://reactnative.dev/docs/platform-specific-code#native-specific-extensions-ie-sharing-code-with-nodejs-and-web.

Let me know if you think it may pose any issues in other circumstances, and an alternative I think is to pass a startup flag if for an application we want to preserve the import with file extension.